### PR TITLE
Snapshot camera state based on image

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.aiohttp_client import (
 )
 
 from .const import (
-    DOMAIN, NAME, VERSION
+    DOMAIN, NAME, VERSION, STATE_DETECTED, STATE_IDLE
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -200,3 +200,10 @@ class FrigateMqttSnapshots(Camera):
     @property
     def available(self) -> bool:
         return self._available
+
+    @property
+    def state(self):
+        """Return the camera state."""
+        if self._last_image is None:
+            return STATE_IDLE
+        return STATE_DETECTED

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -41,3 +41,7 @@ If you have any issues with this you need to open an issue here:
 {ISSUE_URL}
 -------------------------------------------------------------------
 """
+
+# States
+STATE_DETECTED = "active"
+STATE_IDLE = "idle"


### PR DESCRIPTION
This PR updates the snapshot camera's state based on the cameras image.  This makes using a conditional card to display snapshots much easier.