### PR TITLE
Add version to manifest.json

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -2,6 +2,7 @@
   "domain": "frigate",
   "documentation": "https://github.com/blakeblackshear/frigate",
   "name": "Frigate",
+  "version": "1.0.4",
   "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
   "dependencies": [
     "http"


### PR DESCRIPTION
Starting with Home Assistant 2021.3.0, components must include a version in the manifest