### PR TITLE
Create more granular devices

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -25,7 +25,9 @@ SCAN_INTERVAL = timedelta(seconds=5)
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-def get_frigate_device_identifier(entry: ConfigEntry, camera_name: str | None = None) -> tuple[str, str]:
+def get_frigate_device_identifier(
+    entry: ConfigEntry, camera_name: str | None = None
+) -> tuple[str, str]:
     """Get a device identifier."""
     if camera_name:
         return (DOMAIN, f"{entry.entry_id}:{slugify(camera_name)}")
@@ -35,7 +37,7 @@ def get_frigate_device_identifier(entry: ConfigEntry, camera_name: str | None = 
 
 def get_friendly_name(name: str) -> str:
     """Get a friendly version of a name."""
-    return name.replace('_', ' ').title()
+    return name.replace("_", " ").title()
 
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import slugify
 
 from .api import FrigateApiClient
 from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
@@ -22,6 +23,19 @@ from .views import ClipsProxy, NotificationProxy, RecordingsProxy
 SCAN_INTERVAL = timedelta(seconds=5)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+def get_frigate_device_identifier(entry: ConfigEntry, camera_name: str | None = None) -> tuple[str, str]:
+    """Get a device identifier."""
+    if camera_name:
+        return (DOMAIN, f"{entry.entry_id}:{slugify(camera_name)}")
+    else:
+        return (DOMAIN, entry.entry_id)
+
+
+def get_friendly_name(name: str) -> str:
+    """Get a friendly version of a name."""
+    return name.replace('_', ' ').title()
 
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -8,12 +8,12 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
     BinarySensorEntity,
 )
-from . import get_friendly_name, get_frigate_device_identifier
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import get_friendly_name, get_frigate_device_identifier
 from .const import DOMAIN, NAME, VERSION
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -116,6 +116,7 @@ class FrigateMotionSensor(BinarySensorEntity):
         """Return device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "via_device": get_frigate_device_identifier(self._entry),
             "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
     BinarySensorEntity,
 )
+from . import get_friendly_name, get_frigate_device_identifier
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -114,8 +115,8 @@ class FrigateMotionSensor(BinarySensorEntity):
     def device_info(self) -> dict[str, Any]:
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": NAME,
+            "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,
         }
@@ -123,8 +124,7 @@ class FrigateMotionSensor(BinarySensorEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        friendly_camera_name = self._cam_name.replace("_", " ")
-        return f"{friendly_camera_name} {self._obj_name} Motion".title()
+        return f"{get_friendly_name(self._cam_name)} {self._obj_name} Motion".title()
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -80,6 +80,7 @@ class FrigateCamera(Camera):
         """Return the device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self.config_entry, self._name)},
+            "via_device": get_frigate_device_identifier(self.config_entry),
             "name": get_friendly_name(self._name),
             "model": VERSION,
             "manufacturer": NAME,
@@ -189,6 +190,7 @@ class FrigateMqttSnapshots(Camera):
         """Get the device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "via_device": get_frigate_device_identifier(self._entry),
             "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -14,9 +14,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import get_friendly_name, get_frigate_device_identifier
-from .const import (
-    DOMAIN, NAME, VERSION, STATE_DETECTED, STATE_IDLE
-)
+from .const import DOMAIN, NAME, STATE_DETECTED, STATE_IDLE, VERSION
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -79,7 +77,9 @@ class FrigateCamera(Camera):
     def device_info(self) -> dict[str, any]:
         """Return the device information."""
         return {
-            "identifiers": {get_frigate_device_identifier(self.config_entry, self._name)},
+            "identifiers": {
+                get_frigate_device_identifier(self.config_entry, self._name)
+            },
             "via_device": get_frigate_device_identifier(self.config_entry),
             "name": get_friendly_name(self._name),
             "model": VERSION,

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -13,7 +13,10 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN, NAME, STATE_DETECTED, STATE_IDLE, VERSION
+from . import get_friendly_name, get_frigate_device_identifier
+from .const import (
+    DOMAIN, NAME, VERSION, STATE_DETECTED, STATE_IDLE
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -70,14 +73,14 @@ class FrigateCamera(Camera):
     @property
     def name(self):
         """Return the name of the camera."""
-        return f"{self._name.replace('_', ' ')}".title()
+        return get_friendly_name(self._name)
 
     @property
     def device_info(self) -> dict[str, any]:
         """Return the device information."""
         return {
-            "identifiers": {(DOMAIN, self.config_entry.entry_id)},
-            "name": NAME,
+            "identifiers": {get_frigate_device_identifier(self.config_entry, self._name)},
+            "name": get_friendly_name(self._name),
             "model": VERSION,
             "manufacturer": NAME,
         }
@@ -185,8 +188,8 @@ class FrigateMqttSnapshots(Camera):
     def device_info(self):
         """Get the device information."""
         return {
-            "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": NAME,
+            "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,
         }
@@ -194,8 +197,7 @@ class FrigateMqttSnapshots(Camera):
     @property
     def name(self):
         """Return the name of the sensor."""
-        friendly_camera_name = self._cam_name.replace("_", " ")
-        return f"{friendly_camera_name} {self._obj_name}".title()
+        return f"{get_friendly_name(self._cam_name)} {self._obj_name}".title()
 
     async def async_camera_image(self):
         """Return image response."""

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.dt import DEFAULT_TIME_ZONE
 
+from . import get_friendly_name
 from .api import FrigateApiClient
 from .const import DOMAIN
 
@@ -191,7 +192,7 @@ class FrigateSource(MediaSource):
         if identifier["original"] == CLIPS_ROOT:
             title = f"Clips ({count})"
         else:
-            title = f"{' > '.join([s for s in identifier['name'].replace('_', ' ').split('.') if s != '']).title()} ({count})"
+            title = f"{' > '.join([s for s in get_friendly_name(identifier['name']).split('.') if s != '']).title()} ({count})"
 
         base = BrowseMediaSource(
             domain=DOMAIN,
@@ -299,7 +300,7 @@ class FrigateSource(MediaSource):
                     media_class=MEDIA_CLASS_DIRECTORY,
                     children_media_class=MEDIA_CLASS_VIDEO,
                     media_content_type=MEDIA_CLASS_VIDEO,
-                    title=f"{camera.replace('_', ' ').title()} ({count})",
+                    title=f"{get_friendly_name(camera)} ({count})",
                     can_play=False,
                     can_expand=True,
                     thumbnail=None,
@@ -330,7 +331,7 @@ class FrigateSource(MediaSource):
                     media_class=MEDIA_CLASS_DIRECTORY,
                     children_media_class=MEDIA_CLASS_VIDEO,
                     media_content_type=MEDIA_CLASS_VIDEO,
-                    title=f"{label.replace('_', ' ').title()} ({count})",
+                    title=f"{get_friendly_name(label)} ({count})",
                     can_play=False,
                     can_expand=True,
                     thumbnail=None,
@@ -361,7 +362,7 @@ class FrigateSource(MediaSource):
                     media_class=MEDIA_CLASS_DIRECTORY,
                     children_media_class=MEDIA_CLASS_VIDEO,
                     media_content_type=MEDIA_CLASS_VIDEO,
-                    title=f"{zone.replace('_', ' ').title()} ({count})",
+                    title=f"{get_friendly_name(zone)} ({count})",
                     can_play=False,
                     can_expand=True,
                     thumbnail=None,
@@ -612,7 +613,7 @@ class FrigateSource(MediaSource):
     def _generate_recording_title(cls, identifier, folder=None):
         if identifier["camera"] != "":
             if folder is None:
-                return identifier["camera"].replace("_", " ").title()
+                return get_friendly_name(identifier["camera"])
             minute_seconds = folder["name"].replace(".mp4", "")
             return dt.datetime.strptime(
                 f"{identifier['hour']}.{minute_seconds}", "%H.%M.%S"
@@ -623,7 +624,7 @@ class FrigateSource(MediaSource):
                 return dt.datetime.strptime(
                     f"{identifier['hour']}.00.00", "%H.%M.%S"
                 ).strftime("%-I:%M:%S %p")
-            return folder["name"].replace("_", " ").title()
+            return get_friendly_name(folder["name"])
 
         if identifier["day"] != "":
             if folder is None:

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -19,6 +19,7 @@ from .const import (
     PERSON_ICON,
     VERSION,
 )
+from . import get_friendly_name, get_frigate_device_identifier
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -141,8 +142,7 @@ class DetectorSpeedSensor(CoordinatorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        friendly_detector_name = self.detector_name.replace("_", " ")
-        return f"{friendly_detector_name} inference speed".title()
+        return f"{get_friendly_name(self.detector_name)} inference speed".title()
 
     @property
     def state(self):
@@ -185,8 +185,8 @@ class CameraFpsSensor(CoordinatorEntity):
     def device_info(self):
         """Get device information."""
         return {
-            "identifiers": {(DOMAIN, self.config_entry.entry_id)},
-            "name": NAME,
+            "identifiers": {get_frigate_device_identifier(self.config_entry, self.camera_name)},
+            "name": get_friendly_name(self.camera_name),
             "model": VERSION,
             "manufacturer": NAME,
         }
@@ -194,8 +194,7 @@ class CameraFpsSensor(CoordinatorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        friendly_camera_name = self.camera_name.replace("_", " ")
-        return f"{friendly_camera_name} {self.fps_type} FPS".title()
+        return f"{get_friendly_name(self.camera_name)} {self.fps_type} FPS".title()
 
     @property
     def unit_of_measurement(self):
@@ -301,8 +300,8 @@ class FrigateObjectCountSensor(Entity):
         """Get device information."""
 
         return {
-            "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": NAME,
+            "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,
         }
@@ -310,8 +309,7 @@ class FrigateObjectCountSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        friendly_camera_name = self._cam_name.replace("_", " ")
-        return f"{friendly_camera_name} {self._obj_name}".title()
+        return f"{get_friendly_name(self._cam_name)} {self._obj_name}".title()
 
     @property
     def state(self):

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import get_friendly_name, get_frigate_device_identifier
 from .const import (
     CAR_ICON,
     CAT_ICON,
@@ -19,7 +20,6 @@ from .const import (
     PERSON_ICON,
     VERSION,
 )
-from . import get_friendly_name, get_frigate_device_identifier
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -84,6 +84,7 @@ class FrigateFpsSensor(CoordinatorEntity):
 
     @property
     def device_info(self):
+        """Get device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self.config_entry)},
             "name": NAME,
@@ -130,6 +131,7 @@ class DetectorSpeedSensor(CoordinatorEntity):
 
     @property
     def device_info(self):
+        """Get device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self.config_entry)},
             "name": NAME,
@@ -183,7 +185,9 @@ class CameraFpsSensor(CoordinatorEntity):
     def device_info(self):
         """Get device information."""
         return {
-            "identifiers": {get_frigate_device_identifier(self.config_entry, self.camera_name)},
+            "identifiers": {
+                get_frigate_device_identifier(self.config_entry, self.camera_name)
+            },
             "via_device": get_frigate_device_identifier(self.config_entry),
             "name": get_friendly_name(self.camera_name),
             "model": VERSION,

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -84,9 +84,8 @@ class FrigateFpsSensor(CoordinatorEntity):
 
     @property
     def device_info(self):
-        """Get device information."""
         return {
-            "identifiers": {(DOMAIN, self.config_entry.entry_id)},
+            "identifiers": {get_frigate_device_identifier(self.config_entry)},
             "name": NAME,
             "model": VERSION,
             "manufacturer": NAME,
@@ -131,9 +130,8 @@ class DetectorSpeedSensor(CoordinatorEntity):
 
     @property
     def device_info(self):
-        """Get device information."""
         return {
-            "identifiers": {(DOMAIN, self.config_entry.entry_id)},
+            "identifiers": {get_frigate_device_identifier(self.config_entry)},
             "name": NAME,
             "model": VERSION,
             "manufacturer": NAME,
@@ -186,6 +184,7 @@ class CameraFpsSensor(CoordinatorEntity):
         """Get device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self.config_entry, self.camera_name)},
+            "via_device": get_frigate_device_identifier(self.config_entry),
             "name": get_friendly_name(self.camera_name),
             "model": VERSION,
             "manufacturer": NAME,
@@ -301,6 +300,7 @@ class FrigateObjectCountSensor(Entity):
 
         return {
             "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "via_device": get_frigate_device_identifier(self._entry),
             "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -106,6 +106,7 @@ class FrigateSwitch(SwitchEntity):
         """Get device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "via_device": get_frigate_device_identifier(self._entry),
             "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -1,12 +1,12 @@
 """Sensor platform for frigate."""
 import logging
 
-from . import get_friendly_name, get_frigate_device_identifier
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 
+from . import get_friendly_name, get_frigate_device_identifier
 from .const import DOMAIN, NAME, VERSION
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -1,6 +1,7 @@
 """Sensor platform for frigate."""
 import logging
 
+from . import get_friendly_name, get_frigate_device_identifier
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.components.switch import SwitchEntity
@@ -104,8 +105,8 @@ class FrigateSwitch(SwitchEntity):
     def device_info(self):
         """Get device information."""
         return {
-            "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": NAME,
+            "identifiers": {get_frigate_device_identifier(self._entry, self._cam_name)},
+            "name": get_friendly_name(self._cam_name),
             "model": VERSION,
             "manufacturer": NAME,
         }
@@ -113,8 +114,7 @@ class FrigateSwitch(SwitchEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        friendly_camera_name = self._cam_name.replace("_", " ")
-        return f"{friendly_camera_name} {self._switch_name}".title()
+        return f"{get_friendly_name(self._cam_name)} {self._switch_name}".title()
 
     @property
     def is_on(self):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock
 
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
+from custom_components.frigate.const import DOMAIN, NAME, VERSION
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID,
@@ -73,3 +75,42 @@ async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:
     client.async_get_stats = AsyncMock(side_effect=Exception)
     await setup_mock_frigate_config_entry(hass, client=client)
     assert not hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID)
+
+
+async def test_binary_sensor_device_info(hass: HomeAssistant) -> None:
+    """Verify switch device information."""
+    config_entry = await setup_mock_frigate_config_entry(hass)
+
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{config_entry.entry_id}:front_door")}
+    )
+    assert device
+    assert device.manufacturer == NAME
+    assert device.model == VERSION
+
+    entities_from_device = [
+        entry.entity_id
+        for entry in er.async_entries_for_device(entity_registry, device.id)
+    ]
+    assert TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID in entities_from_device
+    assert TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID not in entities_from_device
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{config_entry.entry_id}:steps")}
+    )
+    assert device
+    assert device.manufacturer == NAME
+    assert device.model == VERSION
+
+    entities_from_device = [
+        entry.entity_id
+        for entry in er.async_entries_for_device(entity_registry, device.id)
+    ]
+    assert (
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        not in entities_from_device
+    )
+    assert TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID in entities_from_device


### PR DESCRIPTION
Home Assistant devices are intended to represent physical items that can be assigned to `areas` ([docs](https://developers.home-assistant.io/docs/device_registry_index/#what-is-a-device)). Rather than a single Frigate device, instead expose each Frigate camera as a device -- this allows:
   * Convenient grouping of entities belonging to a single camera (as there are a considerable number of entities this grouping eases exploration of the entities)
   * Assignment of devices to home assistant areas (after setup the user is prompted to assign devices to areas).

Entities not related to a camera (e.g. CPU inference speed) are still tied to the "parent" Frigate device. Note: Another variant of this would be to have no "parent" device at all.

![Screenshot from 2021-05-31 10-45-30](https://user-images.githubusercontent.com/1136829/120227078-60367380-c1fd-11eb-87f9-a746e9ca82d7.png)
![Screenshot from 2021-05-31 10-46-36](https://user-images.githubusercontent.com/1136829/120227159-83612300-c1fd-11eb-867f-f22ed18bf497.png)
