### PR TITLE
Add basic test structure and tests for config_flow

### DIFF
--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -1,17 +1,16 @@
 """Adds config flow for Frigate."""
-from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import callback
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.helpers.typing import DiscoveryInfoType
-import voluptuous as vol
+from __future__ import annotations
+
 import logging
+from typing import Any
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
+import voluptuous as vol
 
 from .api import FrigateApiClient
-from .const import (
-    DOMAIN,
-    PLATFORMS
-)
+from .const import DEFAULT_HOST, DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -22,65 +21,38 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
-    def __init__(self):
-        """Initialize."""
-        self._errors = {}
-
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: dict[str, Any] = None) -> dict[str, Any]:
         """Handle a flow initialized by the user."""
-        self._errors = {}
-        # Ensure mqtt
-        if not 'mqtt' in self.hass.config.components:
-            return self.async_abort(reason="mqtt_required")
-        # Check if already configured
+
+        # Check if another instance is already configured.
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
 
-        if user_input is not None:
-            valid = await self._valid(user_input)
-            if valid:
-                return self.async_create_entry(
-                    title="Frigate", data=user_input
-                )
+        if user_input is None:
+            return self._show_config_form()
 
-            return await self._show_config_form(user_input)
+        try:
+            session = async_create_clientsession(self.hass)
+            client = FrigateApiClient(user_input[CONF_HOST], session)
+            await client.async_get_stats()
+        except Exception:  # pylint: disable=broad-except
+            return self._show_config_form(user_input, errors={"base": "cannot_connect"})
 
-        return await self._show_config_form(user_input)
+        return self.async_create_entry(
+            title="Frigate", data=user_input
+        )
 
-    async def _show_config_form(self, user_input):  # pylint: disable=unused-argument
-        """Show the configuration form to edit location data."""
-        default_host = "http://ccab4aaf-frigate:5000"
-        if not user_input is None:
-            default_host = user_input.get("host", "http://ccab4aaf-frigate:5000")
+    def _show_config_form(
+        self, user_input: dict[str, Any] | None = None, errors: dict[str, Any] | None = None
+    ):  # pylint: disable=unused-argument
+        """Show the configuration form."""
+        if user_input is None:
+            user_input = {}
+
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
-                {vol.Required("host", default=default_host): str}
+                {vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)): str}
             ),
-            errors=self._errors,
+            errors=errors,
         )
-
-    async def _valid(self, input_data):
-        valid = await self._test_credentials(
-            input_data["host"]
-        )
-        if not 'mqtt' in self.hass.config.components:
-            self._errors["base"] = "mqtt"
-        elif valid:
-            return True
-        else:
-            self._errors["base"] = "auth"
-
-        return False
-
-    async def _test_credentials(self, url):
-        """Return true if credentials is valid."""
-        try:
-            session = async_create_clientsession(self.hass)
-            client = FrigateApiClient(url, session)
-            await client.async_get_stats()
-            return True
-        except Exception as e:  # pylint: disable=broad-except
-            _LOGGER.error(e)
-            pass
-        return False

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -30,6 +30,7 @@ CONF_ENABLED = "enabled"
 
 # Defaults
 DEFAULT_NAME = DOMAIN
+DEFAULT_HOST = "http://ccab4aaf-frigate:5000"
 
 
 STARTUP_MESSAGE = f"""

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -10,12 +10,10 @@
             }
         },
         "error": {
-            "auth": "Unable to connect to Frigate.",
-            "mqtt": "MQTT is required for this integration."
+            "cannot_connect": "Failed to connect"
         },
         "abort": {
-            "single_instance_allowed": "Only a single configuration of Frigate is allowed.",
-            "mqtt_required": "MQTT is required for this integration."
+            "single_instance_allowed": "Only a single configuration of Frigate is allowed."
         }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp_cors
+homeassistant==2021.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+pytest-homeassistant-custom-component==0.3.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,39 @@
+"""Tests for the Frigate integration."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.frigate.const import DOMAIN, NAME
+
+TEST_CONFIG_ENTRY_ID = "74565ad414754616000674c87bdc876c"
+TEST_HOST = "http://example.com"
+
+
+def create_mock_frigate_client() -> AsyncMock:
+    """Create mock frigate client."""
+    mock_client = AsyncMock()
+    mock_client.async_get_stats = AsyncMock(return_value={})
+    return mock_client
+
+
+def create_mock_frigate_config_entry(
+    hass: HomeAssistant,
+    data: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+) -> ConfigEntry:
+    """Add a test config entry."""
+    config_entry: MockConfigEntry = MockConfigEntry(
+        entry_id=TEST_CONFIG_ENTRY_ID,
+        domain=DOMAIN,
+        data=data or {CONF_HOST: TEST_HOST},
+        title=NAME,
+        options=options or {},
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Global fixtures for frigate component integration."""
+from typing import Any, Generator
+from unittest.mock import patch
+
+import pytest
+from pytest_homeassistant_custom_component.plugins import (  # noqa: F401
+    enable_custom_integrations,
+)
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+# This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
+# notifications. These calls would fail without this fixture since the persistent_notification
+# integration is never loaded during a test.
+@pytest.fixture(name="skip_notifications", autouse=True)
+def skip_notifications_fixture() -> Generator:
+    """Skip notification calls."""
+    with patch("homeassistant.components.persistent_notification.async_create"), patch(
+        "homeassistant.components.persistent_notification.async_dismiss"
+    ):
+        yield
+
+
+@pytest.fixture(name="auto_enable_custom_integrations", autouse=True)
+def auto_enable_custom_integrations(
+    hass: Any, enable_custom_integrations: Any  # noqa: F811
+) -> None:
+    """Enable custom integrations defined in the test dir."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,89 @@
+"""Test the frigate config flow."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from custom_components.frigate.const import DOMAIN, NAME
+
+from . import TEST_HOST, create_mock_frigate_client, create_mock_frigate_config_entry
+
+_LOGGER = logging.getLogger(__package__)
+
+
+async def test_user_success(hass: HomeAssistant) -> None:
+    """Test successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    mock_client = create_mock_frigate_client()
+
+    with patch(
+        "custom_components.frigate.config_flow.FrigateApiClient",
+        return_value=mock_client,
+    ), patch(
+        "custom_components.frigate.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_client.async_get_stats.called
+
+
+async def test_user_multiple_instances(hass: HomeAssistant) -> None:
+    """Test multiple instances."""
+    # Create another config for this domain.
+    create_mock_frigate_config_entry(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_user_connection_failure(hass: HomeAssistant) -> None:
+    """Test connection failure."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    mock_client = create_mock_frigate_client()
+    mock_client.async_get_stats = AsyncMock(side_effect=asyncio.TimeoutError)
+
+    with patch(
+        "custom_components.frigate.config_flow.FrigateApiClient",
+        return_value=mock_client,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"


### PR DESCRIPTION
   * Add basic skeleton to support tests (e.g. `conftest.py`, `requirements*`)
   * Add tests for `config_flow.py` as a first demo test (test coverage for this file -> 100%)
   * Simplify `config_flow.py` a bit for readability (including removing checks for mqtt, which is unnecessary since the dependency is in `manifest.json`).

For the record, output:

```
(~/src/frigate-hass-integration) $ pytest --cov-report=term-missing --cov=custom_components/frigate tests/
Test session starts (platform: linux, Python 3.8.5, pytest 6.2.4, pytest-sugar 0.9.4)
rootdir: src/frigate-hass-integration
plugins: forked-1.3.0, cov-2.10.1, xdist-2.1.0, aiohttp-0.3.0, test-groups-1.0.3, timeout-1.4.2, sugar-0.9.4, homeassistant-custom-component-0.3.2, requests-mock-1.8.0
collecting ... 
 tests/test_config_flow.py ✓✓✓                                                                                                                                                               100% ██████████

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
custom_components/frigate/__init__.py           58     37    36%   38-75, 83-86, 90-93, 98-111, 116-117
custom_components/frigate/api.py                59     39    34%   23-24, 28-29, 33-36, 40-43, 47-48, 52-53, 59-98
custom_components/frigate/binary_sensor.py      68     68     0%   2-128
custom_components/frigate/camera.py            109    109     0%   2-209
custom_components/frigate/config_flow.py        29      0   100%
custom_components/frigate/const.py              24      0   100%
custom_components/frigate/media_source.py      209    209     0%   2-586
custom_components/frigate/sensor.py            167    167     0%   2-299
custom_components/frigate/switch.py             75     75     0%   2-157
custom_components/frigate/views.py             153     99    35%   25-26, 30, 36-42, 55-81, 93-94, 98, 104-110, 123-149, 161-162, 166-175, 181-188, 201-226, 233-269, 274-288
--------------------------------------------------------------------------
TOTAL                                          951    803    16%


Results (0.30s):
       3 passed
```