### PR TITLE
Minor build fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - build
   pull_request:
   schedule:
     - cron: "17 6 * * *"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,6 @@ repos:
         stages: [manual]
       - id: check-json
         exclude: (.vscode|.devcontainer)
-      - id: no-commit-to-branch
-        args:
-          - --branch=master
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.24.2
     hooks:


### PR DESCRIPTION
* [**Cleanup**] We no longer need to trigger the build on the 'build' branch, since it's now merged into master.
* [**Fix**] Unlike Home Assistant Core (where all commits are to `dev` branch) we do need to allow commits to master. This is why [your merge failed the pre-commit](https://github.com/blakeblackshear/frigate-hass-integration/runs/2760071201?check_suite_focus=true).