### PR TITLE
Add code coverage tracking (codecov)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,3 +72,8 @@ jobs:
       - name: Tests suite
         run: |
           pytest -p no:sugar
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.5.0
+        with:
+          env_vars: OS,PYTHON
+          verbose: true


### PR DESCRIPTION
Add code coverage instrumentation. I find tracking the data encourages me to keep the coverage high!

This requires a [codecov](https://about.codecov.io/sign-up/) account and giving it access to this repo, which you may or may not want/have. If you'd rather use a different coverage system, or not track coverage, no worries. Signing up gives us two things:

   * Instrumentation ([random example from another integration I maintain](https://app.codecov.io/gh/dermotduffy/hass-motioneye)).
   * A badge to shame us into maintaining good coverage <img width="103" alt="Screen Shot 2021-06-06 at 7 59 37 PM" src="https://user-images.githubusercontent.com/1136829/120953440-ce010480-c701-11eb-9bd9-d9efed3684e9.png">
