### PR TITLE
Fix subtle count-by bug

### DIFF
--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -594,9 +594,9 @@ class FrigateSource(MediaSource):
                 if (
                     (after is None or d["timestamp"] >= after)
                     and (before is None or d["timestamp"] < before)
-                    and camera in ("", d["camera"])
-                    and label in ("", d["label"])
-                    and zone in ("", d["zones"])
+                    and (camera == "" or camera in d["camera"])
+                    and (label == "" or label in d["label"])
+                    and (zone == "" or zone in d["zones"])
                 )
             ]
         )


### PR DESCRIPTION
[One of my earlier PRs](https://github.com/blakeblackshear/frigate-hass-integration/pull/63/files#diff-c0c9bfdb652d2f05cf484016f9d05d83d62418f56702111b9313f99f2d137a3dR596) introduced a subtle bug in `_count_by` that the (still in progress) `media_source.py` unittests found (yay unittests). 

d["camera" ] (and label, zone) is a list, not a string, so this invalid "style fix" had the effect of causing count_by to undercount for cameras/labels/zones.

```py
>>> "steps" in ("", ["steps"])
False
```

Unittest PR will come later, I just wanted to get head repaired in the meantime in case it costs someone time debugging.