### PR TITLE
Test Coverage #7: API

### DIFF
--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -15,6 +15,12 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 HEADERS = {"Content-type": "application/json; charset=UTF-8"}
 
+# ==============================================================================
+# Please do not add HomeAssistant specific imports/functionality to this module,
+# so that this library can be optionally moved to a different repo at a later
+# date.
+# ==============================================================================
+
 
 class FrigateApiClient:
     """Frigate API client."""
@@ -56,10 +62,7 @@ class FrigateApiClient:
 
     async def async_get_event_summary(self) -> dict:
         """Get data from the API."""
-        params = {"has_clip": 1}
-        params = urllib.parse.urlencode(
-            {k: v for k, v in params.items() if v is not None and v != ""}
-        )
+        params = urllib.parse.urlencode({"has_clip": 1})
         url = urllib.parse.urljoin(self._host, f"/api/events/summary?{params}")
         return await self.api_wrapper("get", url)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ pytest==6.2.4
 pytest-homeassistant-custom-component==0.4.1
 pylint-pytest
 pylint==2.8.3
+pytest-aiohttp==0.3.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,248 @@
+"""Test the frigate API client."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import Mock, patch
+
+import aiohttp
+from aiohttp import web  # type: ignore
+import pytest
+
+from custom_components.frigate.api import FrigateApiClient
+
+_LOGGER = logging.getLogger(__package__)
+
+# ==============================================================================
+# Please do not add HomeAssistant specific imports/functionality to this test,
+# so that this library can be optionally moved to a different repo at a later
+# date.
+# ==============================================================================
+
+
+@pytest.fixture
+async def aiohttp_session() -> aiohttp.ClientSession:
+    """Test fixture for aiohttp.ClientSerssion."""
+    async with aiohttp.ClientSession() as session:
+        yield session
+
+
+async def _start_frigate_server(aiohttp_server: Any, handlers: list[web.route]) -> Any:
+    """Start a fake Frigate server."""
+    app = web.Application()
+    app.add_routes(handlers)
+    return await aiohttp_server(app)
+
+
+def _assert_request_params(
+    request: web.Request, expected_params: dict[str, str]
+) -> None:
+    """Assert expected parameters."""
+    for key, value in expected_params.items():
+        assert request.query.get(key) == value
+
+
+async def test_async_get_stats(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_config."""
+    stats_in = {"detection_fps": 8.1}
+    stats_handler = Mock(return_value=web.json_response(stats_in))
+
+    server = await _start_frigate_server(
+        aiohttp_server, [web.get("/api/stats", stats_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert stats_in == await frigate_client.async_get_stats()
+
+
+async def test_async_get_events(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_events."""
+    events_in = [
+        {
+            "camera": "front_door",
+            "end_time": 1623643757.837382,
+            "false_positive": False,
+            "has_clip": True,
+            "has_snapshot": False,
+            "id": "1623643750.569992-64ji22",
+            "label": "person",
+            "start_time": 1623643750.569992,
+            "thumbnail": "thumbnail",
+            "top_score": 0.70703125,
+            "zones": [],
+        }
+    ]
+
+    async def events_handler(request: web.Request) -> web.Response:
+        """Events handler."""
+        _assert_request_params(
+            request,
+            {
+                "camera": "test_camera",
+                "label": "test_label",
+                "zone": "test_zone",
+                "after": "test_after",
+                "before": "test_before",
+                "limit": "test_limit",
+                "has_clip": "1",
+            },
+        )
+        return web.json_response(events_in)
+
+    server = await _start_frigate_server(
+        aiohttp_server, [web.get("/api/events", events_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert events_in == await frigate_client.async_get_events(
+        camera="test_camera",
+        label="test_label",
+        zone="test_zone",
+        after="test_after",
+        before="test_before",
+        limit="test_limit",
+    )
+
+
+async def test_async_get_event_summary(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_event_summary."""
+    events_summary_in = [
+        {
+            "camera": "front_door",
+            "count": 76,
+            "day": "2021-06-12",
+            "label": "person",
+            "zones": [],
+        },
+    ]
+
+    async def events_summary_handler(request: web.Request) -> web.Response:
+        """Events summary handler."""
+        _assert_request_params(request, {"has_clip": "1"})
+        return web.json_response(events_summary_in)
+
+    server = await _start_frigate_server(
+        aiohttp_server, [web.get("/api/events/summary", events_summary_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert events_summary_in == await frigate_client.async_get_event_summary()
+
+
+async def test_async_get_config(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_event_summary."""
+    config_in = {"cameras": {"front_door": {"camera_config": "goes here"}}}
+    config_handler = Mock(return_value=web.json_response(config_in))
+
+    server = await _start_frigate_server(
+        aiohttp_server, [web.get("/api/config", config_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert config_in == await frigate_client.async_get_config()
+
+
+async def test_async_get_recordings_folder(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_recordings_folder."""
+    recordings_in = [
+        {
+            "name": "2021-05",
+            "type": "directory",
+            "mtime": "Sun, 04 June 2021 22:47:14 GMT",
+        }
+    ]
+
+    recordings_handler = Mock(return_value=web.json_response(recordings_in))
+
+    server = await _start_frigate_server(
+        aiohttp_server, [web.get("/recordings/moo/", recordings_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert recordings_in == await frigate_client.async_get_recordings_folder("moo")
+
+
+async def test_api_wrapper_methods(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test the general api_wrapper."""
+
+    get_handler = Mock(return_value=web.json_response({"method": "GET"}))
+    put_handler = Mock(return_value=web.json_response({"method": "PUT"}))
+    patch_handler = Mock(return_value=web.json_response({"method": "PATCH"}))
+    post_handler = Mock(return_value=web.json_response({"method": "POST"}))
+
+    server = await _start_frigate_server(
+        aiohttp_server,
+        [
+            web.get("/get", get_handler),
+            web.put("/put", put_handler),
+            web.patch("/patch", patch_handler),
+            web.post("/post", post_handler),
+        ],
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+
+    assert await frigate_client.api_wrapper(
+        method="get", url=server.make_url("/get")
+    ) == {"method": "GET"}
+    assert get_handler.called
+
+    await frigate_client.api_wrapper(method="put", url=server.make_url("/put"))
+    assert put_handler.called
+
+    await frigate_client.api_wrapper(method="patch", url=server.make_url("/patch"))
+    assert patch_handler.called
+
+    await frigate_client.api_wrapper(method="post", url=server.make_url("/post"))
+    assert post_handler.called
+
+
+async def test_api_wrapper_exceptions(
+    caplog: Any, aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test the general api_wrapper."""
+
+    server = await _start_frigate_server(
+        aiohttp_server,
+        [
+            web.get("/get", Mock(return_value=web.json_response({}))),
+        ],
+    )
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+
+    with patch.object(aiohttp_session, "get", side_effect=asyncio.TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
+            await frigate_client.api_wrapper(method="get", url=server.make_url("/get"))
+            assert "Timeout error" in caplog.text
+    caplog.clear()
+
+    with patch.object(aiohttp_session, "get", side_effect=TypeError):
+        with pytest.raises(TypeError):
+            await frigate_client.api_wrapper(method="get", url=server.make_url("/get"))
+            assert "Error parsing information" in caplog.text
+    caplog.clear()
+
+    with patch.object(aiohttp_session, "get", side_effect=aiohttp.ClientError):
+        with pytest.raises(aiohttp.ClientError):
+            await frigate_client.api_wrapper(method="get", url=server.make_url("/get"))
+            assert "Error fetching information" in caplog.text
+    caplog.clear()
+
+    with patch.object(aiohttp_session, "get", side_effect=Exception):
+        with pytest.raises(Exception):
+            await frigate_client.api_wrapper(method="get", url=server.make_url("/get"))
+            assert "Something really wrong happened" in caplog.text
+    caplog.clear()


### PR DESCRIPTION
To get this into Core, `FrigateApiClient` will need to be moved to a separate repo at a later date. As such, these API tests are written to not rely on HomeAssistant directly.

```
collecting ... 
 tests/test_api.py ✓✓✓✓✓✓✓                                                                                                                                                                    20% ██        
 tests/test_binary_sensor.py ✓✓✓✓                                                                                                                                                             31% ███▎      
 tests/test_camera.py ✓✓✓✓                                                                                                                                                                    43% ████▍     
 tests/test_config_flow.py ✓✓✓                                                                                                                                                                51% █████▎    
 tests/test_sensor.py ✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                            86% ████████▋ 
 tests/test_switch.py ✓✓✓✓✓                                                                                                                                                                  100% ██████████

----------- coverage: platform linux, python 3.8.5-final-0 -----------
Name                                         Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------
custom_components/frigate/__init__.py           70      5    93%   119-125, 130
custom_components/frigate/api.py                60      0   100%
custom_components/frigate/binary_sensor.py      59      0   100%
custom_components/frigate/camera.py             99      0   100%
custom_components/frigate/config_flow.py        29      0   100%
custom_components/frigate/const.py              27      0   100%
custom_components/frigate/media_source.py      222    222     0%   2-715
custom_components/frigate/sensor.py            176      0   100%
custom_components/frigate/switch.py             67      0   100%
custom_components/frigate/views.py             153     93    39%   32, 38-44, 57-83, 100, 106-112, 125-151, 168-181, 187-194, 207-232, 237-273, 278-292
--------------------------------------------------------------------------
TOTAL                                          962    320    67%
```

(Stats do not include https://github.com/blakeblackshear/frigate-hass-integration/pull/74)

