### PR TITLE
Change date formats to ISO 8601 and time formats to 24h.

### DIFF
--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -20,6 +20,7 @@ from homeassistant.components.media_source.models import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util.dt import DEFAULT_TIME_ZONE
 
 from . import get_friendly_name
@@ -267,7 +268,7 @@ class FrigateMediaSource(MediaSource):
                 identifier=f"clips/{event['camera']}-{event['id']}.mp4",
                 media_class=MEDIA_CLASS_VIDEO,
                 media_content_type=MEDIA_TYPE_VIDEO,
-                title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime('%x %I:%M %p')} {event['label'].capitalize()} {int(event['top_score']*100)}% | {int(event['end_time']-event['start_time'])}s",
+                title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{int(event['end_time']-event['start_time'])}s, {event['label'].capitalize()} {int(event['top_score']*100)}%]",
                 can_play=True,
                 can_expand=False,
                 thumbnail=f"data:image/jpeg;base64,{event['thumbnail']}",
@@ -615,13 +616,13 @@ class FrigateMediaSource(MediaSource):
             minute_seconds = folder["name"].replace(".mp4", "")
             return dt.datetime.strptime(
                 f"{identifier['hour']}.{minute_seconds}", "%H.%M.%S"
-            ).strftime("%-I:%M:%S %p")
+            ).strftime("%T")
 
         if identifier["hour"] != "":
             if folder is None:
                 return dt.datetime.strptime(
                     f"{identifier['hour']}.00.00", "%H.%M.%S"
-                ).strftime("%-I:%M:%S %p")
+                ).strftime("%T")
             return get_friendly_name(folder["name"])
 
         if identifier["day"] != "":
@@ -630,7 +631,7 @@ class FrigateMediaSource(MediaSource):
                     f"{identifier['year_month']}-{identifier['day']}", "%Y-%m-%d"
                 ).strftime("%B %d")
             return dt.datetime.strptime(f"{folder['name']}.00.00", "%H.%M.%S").strftime(
-                "%-I:%M:%S %p"
+                "%T"
             )
 
         if identifier["year_month"] != "":

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -184,7 +184,7 @@ async def test_async_browse_media_clips_drilldown(
         "can_expand": False,
         "children_media_class": None,
         "thumbnail": "data:image/jpeg;base64,thumbnail",
-        "title": "06/11/21 11:36 PM Person 72% | 8s",
+        "title": "2021-06-11 23:36:23 [8s, Person 72%]",
     } in media.as_dict()["children"]
 
     assert {
@@ -494,7 +494,7 @@ async def test_async_browse_media_recordings_root(
                 "media_content_id": "media-source://frigate/recordings/2021-06/04/15/",
                 "media_content_type": "video",
                 "thumbnail": None,
-                "title": "3:00:00 PM",
+                "title": "15:00:00",
             }
         ],
     }
@@ -519,7 +519,7 @@ async def test_async_browse_media_recordings_root(
     )
 
     assert media.as_dict() == {
-        "title": "3:00:00 PM",
+        "title": "15:00:00",
         "media_class": "directory",
         "media_content_type": "video",
         "media_content_id": "media-source://frigate/recordings/2021-06/04/15/",
@@ -600,7 +600,7 @@ async def test_async_browse_media_recordings_for_camera(
                 "media_content_id": "media-source://frigate/recordings/2021-06/04/15/front_door/46.08.mp4",
                 "media_content_type": "video",
                 "thumbnail": None,
-                "title": "3:46:08 PM",
+                "title": "15:46:08",
             },
             {
                 "can_expand": False,
@@ -610,7 +610,7 @@ async def test_async_browse_media_recordings_for_camera(
                 "media_content_id": "media-source://frigate/recordings/2021-06/04/15/front_door/47.08.mp4",
                 "media_content_type": "video",
                 "thumbnail": None,
-                "title": "3:47:08 PM",
+                "title": "15:47:08",
             },
         ],
     }


### PR DESCRIPTION
Change the default date/time format to the Home Assistant Core standard (ISO 8601) and the time format to 24h. This is a purely subjective choice, and will make some people unhappy -- nevertheless I think this better aligns with the HA default. 

Notes:
   * There is no way to get the [Home Assistant date/time format settings](https://www.home-assistant.io/blog/2021/06/02/release-20216/#time-format-settings) from the frontend into an integration, it is purely used on the frontend to localize entity states (e.g. a sensor with a date value). For raw strings (e.g. media browser) being sent from an integration to the frontend, there are no apparent localization opportunity.

Other options:
   * Leave it as-is, US-centric times and UNIX locale tied dates.
   * Add a config_flow option to allow datetime format. I can find no other Core integration that do this (and suspect it would not be accepted to Core).

<img width="195" alt="Screen Shot 2021-06-16 at 9 31 18 PM" src="https://user-images.githubusercontent.com/1136829/122332325-129f5380-ceeb-11eb-8684-e8b246c07b6b.png">

Relevant (and I would suggest closing): https://github.com/blakeblackshear/frigate-hass-integration/issues/9 , https://github.com/blakeblackshear/frigate-hass-integration/issues/25 , 