### PR TITLE
Convert media source identifiers to structured data

### DIFF
--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -197,6 +197,10 @@ class RecordingIdentifier(Identifier):
         default=None, validator=[attr.validators.instance_of((str, type(None)))]
     )
 
+    recording_name: str | None = attr.ib(
+        default=None, validator=[attr.validators.instance_of((str, type(None)))]
+    )
+
     @classmethod
     def from_str(cls, data: str) -> RecordingIdentifier | None:
         """Generate a RecordingIdentifier from a string."""
@@ -210,6 +214,7 @@ class RecordingIdentifier(Identifier):
                 day=cls._get_index(parts, 2),
                 hour=cls._get_index(parts, 3),
                 camera=cls._get_index(parts, 4),
+                recording_name=cls._get_index(parts, 5),
             )
         except ValueError:
             return None
@@ -225,6 +230,7 @@ class RecordingIdentifier(Identifier):
                     f"{self.day:02}" if self.day is not None else None,
                     f"{self.hour:02}" if self.hour is not None else None,
                     self.camera,
+                    self.recording_name,
                 )
             ]
         )
@@ -243,6 +249,7 @@ class RecordingIdentifier(Identifier):
             f"{self.day:02}" if self.day is not None else None,
             f"{self.hour:02}" if self.hour is not None else None,
             self.camera,
+            self.recording_name,
         ]
 
         out_parts = []
@@ -940,7 +947,9 @@ class FrigateMediaSource(MediaSource):
             base.children.append(
                 BrowseMediaSource(
                     domain=DOMAIN,
-                    identifier=f"{identifier}/{recording['name']}",
+                    identifier=attr.evolve(
+                        identifier, recording_name=recording["name"]
+                    ),
                     media_class=MEDIA_CLASS_VIDEO,
                     media_content_type=MEDIA_TYPE_VIDEO,
                     title=title,

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -95,7 +95,7 @@ async def test_async_browse_media_root(hass: HomeAssistant) -> None:
                 "title": "Recordings",
                 "media_class": "directory",
                 "media_content_type": "video",
-                "media_content_id": "media-source://frigate/recordings////",
+                "media_content_id": "media-source://frigate/recordings/////",
                 "can_play": False,
                 "can_expand": True,
                 "children_media_class": "video",
@@ -407,7 +407,7 @@ async def test_async_browse_media_recordings_root(
         "title": "Recordings",
         "media_class": "directory",
         "media_content_type": "video",
-        "media_content_id": "media-source://frigate/recordings////",
+        "media_content_id": "media-source://frigate/recordings/////",
         "can_play": False,
         "can_expand": True,
         "children_media_class": "video",
@@ -418,7 +418,7 @@ async def test_async_browse_media_recordings_root(
                 "can_play": False,
                 "children_media_class": "video",
                 "media_class": "directory",
-                "media_content_id": "media-source://frigate/recordings/2021-06///",
+                "media_content_id": "media-source://frigate/recordings/2021-06////",
                 "media_content_type": "video",
                 "thumbnail": None,
                 "title": "June 2021",
@@ -449,7 +449,7 @@ async def test_async_browse_media_recordings_root(
         "title": "June 2021",
         "media_class": "directory",
         "media_content_type": "video",
-        "media_content_id": "media-source://frigate/recordings/2021-06///",
+        "media_content_id": "media-source://frigate/recordings/2021-06////",
         "can_play": False,
         "can_expand": True,
         "children_media_class": "video",
@@ -460,7 +460,7 @@ async def test_async_browse_media_recordings_root(
                 "can_play": False,
                 "children_media_class": "video",
                 "media_class": "directory",
-                "media_content_id": "media-source://frigate/recordings/2021-06/04//",
+                "media_content_id": "media-source://frigate/recordings/2021-06/04///",
                 "media_content_type": "video",
                 "thumbnail": None,
                 "title": "June 04",
@@ -488,7 +488,7 @@ async def test_async_browse_media_recordings_root(
         "title": "June 04",
         "media_class": "directory",
         "media_content_type": "video",
-        "media_content_id": "media-source://frigate/recordings/2021-06/04//",
+        "media_content_id": "media-source://frigate/recordings/2021-06/04///",
         "can_play": False,
         "can_expand": True,
         "children_media_class": "video",
@@ -499,7 +499,7 @@ async def test_async_browse_media_recordings_root(
                 "can_play": False,
                 "children_media_class": "video",
                 "media_class": "directory",
-                "media_content_id": "media-source://frigate/recordings/2021-06/04/15/",
+                "media_content_id": "media-source://frigate/recordings/2021-06/04/15//",
                 "media_content_type": "video",
                 "thumbnail": None,
                 "title": "15:00:00",
@@ -530,7 +530,7 @@ async def test_async_browse_media_recordings_root(
         "title": "15:00:00",
         "media_class": "directory",
         "media_content_type": "video",
-        "media_content_id": "media-source://frigate/recordings/2021-06/04/15/",
+        "media_content_id": "media-source://frigate/recordings/2021-06/04/15//",
         "can_play": False,
         "can_expand": True,
         "children_media_class": "video",
@@ -541,7 +541,7 @@ async def test_async_browse_media_recordings_root(
                 "can_play": False,
                 "children_media_class": "video",
                 "media_class": "directory",
-                "media_content_id": "media-source://frigate/recordings/2021-06/04/15/front_door",
+                "media_content_id": "media-source://frigate/recordings/2021-06/04/15/front_door/",
                 "media_content_type": "video",
                 "thumbnail": None,
                 "title": "Front Door",
@@ -551,7 +551,7 @@ async def test_async_browse_media_recordings_root(
                 "can_play": False,
                 "children_media_class": "video",
                 "media_class": "directory",
-                "media_content_id": "media-source://frigate/recordings/2021-06/04/15/sitting_room",
+                "media_content_id": "media-source://frigate/recordings/2021-06/04/15/sitting_room/",
                 "media_content_type": "video",
                 "thumbnail": None,
                 "title": "Sitting Room",
@@ -607,7 +607,7 @@ async def test_async_browse_media_recordings_for_camera(
         "title": "Front Door",
         "media_class": "directory",
         "media_content_type": "video",
-        "media_content_id": "media-source://frigate/recordings/2021-06/04/15/front_door",
+        "media_content_id": "media-source://frigate/recordings/2021-06/04/15/front_door/",
         "can_play": False,
         "can_expand": True,
         "children_media_class": "video",
@@ -740,7 +740,7 @@ async def test_clips_identifier() -> None:
 
 async def test_recordings_identifier() -> None:
     """Test recordings identifier."""
-    identifier_in = "recordings/2021-06/04/15/front_door"
+    identifier_in = "recordings/2021-06/04/15/front_door/media.mp4"
     identifier = Identifier.from_str(identifier_in)
 
     assert identifier
@@ -748,6 +748,7 @@ async def test_recordings_identifier() -> None:
     assert identifier.year_month == "2021-06"
     assert identifier.day == 4
     assert identifier.hour == 15
+    assert identifier.recording_name == "media.mp4"
     assert str(identifier) == identifier_in
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
   * Convert from string manipulated identifiers to structured data identifiers (`attr.s`) in order to:
      * Encapsulate serialization/deserialization of the identifiers in a single place, to allow easier future modifications of the identifiers (which I hope to take advantage of shortly).
      * Improve code readability by not having to copy the strings all over the place.
      * Significantly improved validation of identifiers earlier in the code (vs something surprising breaking later).
   * If people have copied recording  or clips identifiers, they should continue to work.
     