### PR TITLE
Support multiple Frigate instances

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -24,7 +24,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import slugify
 
 from .api import FrigateApiClient, FrigateApiClientError
-from .const import DOMAIN, PLATFORMS, STARTUP_MESSAGE
+from .const import (
+    ATTR_CLIENT,
+    ATTR_CONFIG,
+    ATTR_COORDINATOR,
+    DOMAIN,
+    PLATFORMS,
+    STARTUP_MESSAGE,
+)
 from .views import ClipsProxyView, NotificationsProxyView, RecordingsProxyView
 
 SCAN_INTERVAL = timedelta(seconds=5)
@@ -76,39 +83,34 @@ def get_cameras_zones_and_objects(config: dict[str, Any]) -> {(str, str)}:
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up this integration using YAML is not supported."""
+    _LOGGER.info(STARTUP_MESSAGE)
+
+    hass.data.setdefault(DOMAIN, {})
+
+    session = async_get_clientsession(hass)
+    hass.http.register_view(ClipsProxyView(session))
+    hass.http.register_view(RecordingsProxyView(session))
+    hass.http.register_view(NotificationsProxyView(session))
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
-    if hass.data.get(DOMAIN) is None:
-        hass.data.setdefault(DOMAIN, {})
-        _LOGGER.info(STARTUP_MESSAGE)
 
-    frigate_url = hass.data[DOMAIN][CONF_URL] = entry.data.get(CONF_URL)
-
-    # register views
-    websession = hass.helpers.aiohttp_client.async_get_clientsession()
-    hass.http.register_view(ClipsProxyView(frigate_url, websession))
-    hass.http.register_view(RecordingsProxyView(frigate_url, websession))
-    hass.http.register_view(NotificationsProxyView(frigate_url, websession))
-
-    # setup api polling
-    session = async_get_clientsession(hass)
-    client = FrigateApiClient(frigate_url, session)
-
-    # start the coordinator
+    client = FrigateApiClient(entry.data.get(CONF_URL), async_get_clientsession(hass))
     coordinator = FrigateDataUpdateCoordinator(hass, client=client)
     await coordinator.async_config_entry_first_refresh()
-
-    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     try:
         config = await client.async_get_config()
     except FrigateApiClientError as exc:
         raise ConfigEntryNotReady from exc
 
-    hass.data[DOMAIN]["config"] = config
+    hass.data[DOMAIN][entry.entry_id] = {
+        ATTR_COORDINATOR: coordinator,
+        ATTR_CLIENT: client,
+        ATTR_CONFIG: config,
+    }
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     entry.add_update_listener(_async_entry_updated)

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -11,6 +11,7 @@ import logging
 import re
 from typing import Any, Final
 
+from custom_components.frigate.config_flow import get_config_entry_title
 from homeassistant.components.mqtt.models import Message
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.config_entries import ConfigEntry
@@ -157,7 +158,9 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
         data = {**config_entry.data}
         data[CONF_URL] = data.pop(CONF_HOST)
-        hass.config_entries.async_update_entry(config_entry, data=data)
+        hass.config_entries.async_update_entry(
+            config_entry, data=data, title=get_config_entry_title(data[CONF_URL])
+        )
         config_entry.version = 2
 
         @callback

--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -75,11 +75,9 @@ class FrigateApiClient:
         """Get data from the API."""
         return await self.api_wrapper("get", str(URL(self._host) / "api/config"))
 
-    async def async_get_recordings_folder(self, path) -> dict:
+    async def async_get_path(self, path) -> dict:
         """Get data from the API."""
-        return await self.api_wrapper(
-            "get", str(URL(self._host) / f"recordings/{path}/")
-        )
+        return await self.api_wrapper("get", str(URL(self._host) / f"{path}/"))
 
     async def api_wrapper(
         self,

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -20,7 +20,7 @@ from . import (
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
 )
-from .const import DOMAIN, NAME, VERSION
+from .const import ATTR_CONFIG, DOMAIN, NAME, VERSION
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Binary sensor entry setup."""
-    frigate_config = hass.data[DOMAIN]["config"]
+    frigate_config = hass.data[DOMAIN][entry.entry_id][ATTR_CONFIG]
     async_add_entities(
         [
             FrigateMotionSensor(entry, frigate_config, cam_name, obj)

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -24,7 +24,7 @@ from . import (
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
 )
-from .const import DOMAIN, NAME, STATE_DETECTED, STATE_IDLE, VERSION
+from .const import ATTR_CONFIG, DOMAIN, NAME, STATE_DETECTED, STATE_IDLE, VERSION
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ async def async_setup_entry(
 ) -> None:
     """Camera entry setup."""
 
-    config = hass.data[DOMAIN]["config"]
+    config = hass.data[DOMAIN][entry.entry_id][ATTR_CONFIG]
 
     async_add_entities(
         [

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_URL
@@ -15,6 +16,15 @@ from .api import FrigateApiClient, FrigateApiClientError
 from .const import DEFAULT_HOST, DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def get_config_entry_title(url_str: str) -> str:
+    """Get the title of a config entry from the URL."""
+
+    # Strip the scheme from the URL as it's not that interesting in the title
+    # and space is limited on the integrations page.
+    url = URL(url_str)
+    return str(url)[len(url.scheme + "://") :]
 
 
 class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -50,7 +60,9 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if existing_entry.data.get(CONF_URL) == user_input[CONF_URL]:
                 return self.async_abort(reason="already_configured")
 
-        return self.async_create_entry(title=f"{user_input[CONF_URL]}", data=user_input)
+        return self.async_create_entry(
+            title=get_config_entry_title(user_input[CONF_URL]), data=user_input
+        )
 
     def _show_config_form(
         self,

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -31,6 +31,8 @@ MS = "ms"
 ATTR_CLIENT = "client"
 ATTR_CONFIG = "config"
 ATTR_COORDINATOR = "coordinator"
+ATTR_MQTT = "mqtt"
+ATTR_CLIENT_ID = "client_id"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -2,7 +2,6 @@
 # Base component constants
 NAME = "Frigate"
 DOMAIN = "frigate"
-DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.0.1"
 ISSUE_URL = "https://github.com/blakeblackshear/frigate-hass-integration/issues"
 
@@ -28,8 +27,10 @@ PLATFORMS = [SENSOR, CAMERA, SWITCH, BINARY_SENSOR]
 FPS = "fps"
 MS = "ms"
 
-# Configuration and options
-CONF_ENABLED = "enabled"
+# Attributes
+ATTR_CLIENT = "client"
+ATTR_CONFIG = "config"
+ATTR_COORDINATOR = "coordinator"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -21,7 +21,6 @@ from homeassistant.components.media_source.models import (
     MediaSourceItem,
     PlayMedia,
 )
-from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import DATE_STR_FORMAT
 from homeassistant.util.dt import DEFAULT_TIME_ZONE

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -388,12 +388,9 @@ class FrigateMediaSource(MediaSource):
         return client
 
     def _get_default_config_entry_id(self) -> str | None:
-        """Get the default config_entry_id for an identifier."""
-
+        """Get the default config_entry_id if any."""
         default_config_entry = get_default_config_entry(self.hass)
-        if default_config_entry:
-            return default_config_entry.entry_id
-        return None
+        return default_config_entry.entry_id if default_config_entry else None
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -29,6 +29,7 @@ from homeassistant.util.dt import DEFAULT_TIME_ZONE
 from . import get_friendly_name
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import ATTR_CLIENT, DOMAIN, NAME
+from .views import get_default_config_entry
 
 _LOGGER = logging.getLogger(__name__)
 MIME_TYPE = "video/mp4"
@@ -389,15 +390,9 @@ class FrigateMediaSource(MediaSource):
     def _get_default_config_entry_id(self) -> str | None:
         """Get the default config_entry_id for an identifier."""
 
-        frigate_config_entries = self.hass.config_entries.async_entries(DOMAIN)
-
-        if len(frigate_config_entries) == 1:
-            # For backwards compatibility if there's only a single Frigate
-            # instance, the config entry defaults to that entry.
-            return frigate_config_entries[0].entry_id
-
-        # If there isn't exactly 1 Frigate instance, there is no default (and
-        # the identifier must specify explicitly).
+        default_config_entry = get_default_config_entry(self.hass)
+        if default_config_entry:
+            return default_config_entry.entry_id
         return None
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -21,6 +21,8 @@ from . import (
     get_frigate_entity_unique_id,
 )
 from .const import (
+    ATTR_CONFIG,
+    ATTR_COORDINATOR,
     DOMAIN,
     FPS,
     ICON_CAR,
@@ -43,7 +45,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Sensor entry setup."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id][ATTR_COORDINATOR]
 
     entities = []
     for key, value in coordinator.data.items():
@@ -61,7 +63,7 @@ async def async_setup_entry(
                 [CameraFpsSensor(coordinator, entry, key, t) for t in CAMERA_FPS_TYPES]
             )
 
-    frigate_config = hass.data[DOMAIN]["config"]
+    frigate_config = hass.data[DOMAIN][entry.entry_id][ATTR_CONFIG]
     entities.extend(
         [
             FrigateObjectCountSensor(entry, frigate_config, cam_name, obj)

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -19,6 +19,7 @@ from . import (
     get_frigate_entity_unique_id,
 )
 from .const import (
+    ATTR_CONFIG,
     DOMAIN,
     ICON_FILM_MULTIPLE,
     ICON_IMAGE_MULTIPLE,
@@ -34,7 +35,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Switch entry setup."""
-    frigate_config = hass.data[DOMAIN]["config"]
+    frigate_config = hass.data[DOMAIN][entry.entry_id][ATTR_CONFIG]
 
     entities = []
     for camera in frigate_config["cameras"].keys():

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -14,7 +14,7 @@
             "invalid_url": "Invalid URL"
         },
         "abort": {
-            "single_instance_allowed": "Only a single configuration of Frigate is allowed."
+            "already_configured": "Device is already configured"
         }
     }
 }

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -14,8 +14,8 @@ from yarl import URL
 from custom_components.frigate.const import DOMAIN
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_HASS
-from homeassistant.const import CONF_URL, HTTP_BAD_REQUEST, HTTP_NOT_FOUND
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL, HTTP_BAD_REQUEST, HTTP_NOT_FOUND
 from homeassistant.core import HomeAssistant
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -62,6 +62,16 @@ def get_config_entry_for_frigate_instance_id(
     return None
 
 
+def get_frigate_instance_id_for_config_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> ConfigEntry | None:
+    """Get a frigate_instance_id for a ConfigEntry."""
+
+    config = hass.data[DOMAIN].get(config_entry.entry_id, {}).get(ATTR_CONFIG, {})
+    return get_frigate_instance_id(config) if config else None
+
+
 class ProxyView(HomeAssistantView):
     """HomeAssistant view."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp_cors==0.7.0
+attr
 homeassistant==2021.6.2
 paho-mqtt==1.5.1
 homeassistant==2021.6.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,6 +33,7 @@ TEST_SENSOR_FRONT_DOOR_SKIPPED_FPS_ENTITY_ID = "sensor.front_door_skipped_fps"
 
 TEST_CONFIG_ENTRY_ID = "74565ad414754616000674c87bdc876c"
 TEST_URL = "http://example.com"
+TEST_FRIGATE_INSTANCE_ID = "frigate_client_id"
 TEST_CONFIG = {
     "cameras": {
         "front_door": {
@@ -113,7 +114,7 @@ TEST_CONFIG = {
     "logger": {"default": "INFO", "logs": {}},
     "model": {"height": 320, "width": 320},
     "mqtt": {
-        "client_id": "frigate",
+        "client_id": TEST_FRIGATE_INSTANCE_ID,
         "host": "mqtt",
         "port": 1883,
         "stats_interval": 60,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 from aiohttp import web
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.frigate.const import DOMAIN, NAME
+from custom_components.frigate.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
@@ -262,13 +262,15 @@ def create_mock_frigate_config_entry(
     hass: HomeAssistant,
     data: dict[str, Any] | None = None,
     options: dict[str, Any] | None = None,
+    entry_id: str | None = TEST_CONFIG_ENTRY_ID,
+    title: str | None = TEST_URL,
 ) -> ConfigEntry:
     """Add a test config entry."""
     config_entry: MockConfigEntry = MockConfigEntry(
-        entry_id=TEST_CONFIG_ENTRY_ID,
+        entry_id=entry_id,
         domain=DOMAIN,
         data=data or {CONF_URL: TEST_URL},
-        title=NAME,
+        title=title,
         options=options or {},
         version=2,
     )
@@ -288,8 +290,6 @@ async def setup_mock_frigate_config_entry(
     with patch(
         "custom_components.frigate.FrigateApiClient",
         return_value=client,
-    ), patch(
-        "custom_components.frigate.media_source.FrigateApiClient", return_value=client
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,10 +146,10 @@ async def test_async_get_config(
     assert config_in == await frigate_client.async_get_config()
 
 
-async def test_async_get_recordings_folder(
+async def test_async_get_path(
     aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
 ) -> None:
-    """Test async_get_recordings_folder."""
+    """Test async_get_path."""
     recordings_in = [
         {
             "name": "2021-05",
@@ -165,7 +165,7 @@ async def test_async_get_recordings_folder(
     )
 
     frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
-    assert recordings_in == await frigate_client.async_get_recordings_folder("moo")
+    assert recordings_in == await frigate_client.async_get_path("recordings/moo")
 
 
 async def test_api_wrapper_methods(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -43,7 +43,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] == "create_entry"
-    assert result["title"] == TEST_URL
+    assert result["title"] == "example.com"
     assert result["data"] == {
         CONF_URL: TEST_URL,
     }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -76,8 +76,8 @@ async def test_entry_migration_v1_to_v2(hass: HomeAssistant) -> None:
     config_entry: MockConfigEntry = MockConfigEntry(
         entry_id=TEST_CONFIG_ENTRY_ID,
         domain=DOMAIN,
-        data={CONF_HOST: "http://host"},
-        title="http://host",
+        data={CONF_HOST: "http://host:456"},
+        title="Frigate",
         version=1,
     )
 
@@ -121,6 +121,7 @@ async def test_entry_migration_v1_to_v2(hass: HomeAssistant) -> None:
     assert CONF_HOST not in config_entry.data
     assert CONF_URL in config_entry.data
     assert config_entry.version == 2
+    assert config_entry.title == "host:456"
 
     # Ensure all the old entity unique ids are removed.
     for platform, unique_id in old_unique_ids:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import (
+    TEST_FRIGATE_INSTANCE_ID,
     create_mock_frigate_client,
     create_mock_frigate_config_entry,
     setup_mock_frigate_config_entry,
@@ -205,7 +206,7 @@ async def test_headers(
     assert resp.status == HTTP_OK
 
 
-async def test_clips_with_config_entry_ids(
+async def test_clips_with_frigate_instance_id(
     hass_client_local_frigate: Any,
     hass: Any,
 ) -> None:
@@ -214,25 +215,25 @@ async def test_clips_with_config_entry_ids(
     frigate_entries = hass.config_entries.async_entries(DOMAIN)
     assert frigate_entries
 
-    # A single entry id specified.
+    # A Frigate instance id is specified.
     resp = await hass_client_local_frigate.get(
-        f"/api/frigate/{frigate_entries[0].entry_id}/clips/present"
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/clips/present"
     )
     assert resp.status == HTTP_OK
 
-    # An invalid entry id specified.
+    # An invalid instance id is specified.
     resp = await hass_client_local_frigate.get(
-        "/api/frigate/NOT_A_REAL_ENTRY_ID/clips/present"
+        "/api/frigate/NOT_A_REAL_ID/clips/present"
     )
     assert resp.status == HTTP_BAD_REQUEST
 
-    # No entry id specified when there are multiple entries.
+    # No default allowed when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     resp = await hass_client_local_frigate.get("/api/frigate/clips/present")
     assert resp.status == HTTP_BAD_REQUEST
 
 
-async def test_recordings_with_config_entry_ids(
+async def test_recordings_with_frigate_instance_id(
     hass_client_local_frigate: Any,
     hass: Any,
 ) -> None:
@@ -241,25 +242,25 @@ async def test_recordings_with_config_entry_ids(
     frigate_entries = hass.config_entries.async_entries(DOMAIN)
     assert frigate_entries
 
-    # A single entry id specified.
+    # A Frigate instance id is specified.
     resp = await hass_client_local_frigate.get(
-        f"/api/frigate/{frigate_entries[0].entry_id}/recordings/present"
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/recordings/present"
     )
     assert resp.status == HTTP_OK
 
-    # An invalid entry id specified.
+    # An invalid instance id is specified.
     resp = await hass_client_local_frigate.get(
-        "/api/frigate/NOT_A_REAL_ENTRY_ID/recordings/present"
+        "/api/frigate/NOT_A_REAL_ID/recordings/present"
     )
     assert resp.status == HTTP_BAD_REQUEST
 
-    # No entry id specified when there are multiple entries.
+    # No default allowed when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     resp = await hass_client_local_frigate.get("/api/frigate/recordings/present")
     assert resp.status == HTTP_BAD_REQUEST
 
 
-async def test_notifications_with_config_entry_ids(
+async def test_notifications_with_frigate_instance_id(
     hass_client_local_frigate: Any,
     hass: Any,
 ) -> None:
@@ -268,20 +269,20 @@ async def test_notifications_with_config_entry_ids(
     frigate_entries = hass.config_entries.async_entries(DOMAIN)
     assert frigate_entries
 
-    # A single entry id specified.
+    # A Frigate instance id is specified.
     resp = await hass_client_local_frigate.get(
-        f"/api/frigate/{frigate_entries[0].entry_id}"
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}"
         "/notifications/event_id/snapshot.jpg"
     )
     assert resp.status == HTTP_OK
 
-    # An invalid entry id specified.
+    # An invalid instance id is specified.
     resp = await hass_client_local_frigate.get(
-        "/api/frigate/NOT_A_REAL_ENTRY_ID/notifications/event_id/snapshot.jpg"
+        "/api/frigate/NOT_A_REAL_ID/notifications/event_id/snapshot.jpg"
     )
     assert resp.status == HTTP_BAD_REQUEST
 
-    # No entry id specified when there are multiple entries.
+    # No default allowed when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     resp = await hass_client_local_frigate.get(
         "/api/frigate/notifications/event_id/snapshot.jpg"


### PR DESCRIPTION
Update the integration to support multiple Frigate instances is suitably configured. Highlights:

   * Media browser: Uses the new (https://github.com/blakeblackshear/frigate-hass-integration/pull/88) structured identifiers to seamlessly pass the config entry through the clip search functionality.
   * Clean up the `data` dictionary for the integration so it is indexed by config entry id only, and have a clean consistent dict under each entry.
   * Full backwards compatibility for both views and media browser -- if no "frigate instance id" is specified, and only one Frigate instance configured, that one is used by default. If multiple Frigate are configured, there is no default.

Update: The MQTT `client_id` field (and not the config entry id) is used to differentiate between frigate server instances, as per discussion on this PR. It seems pretty messy/breaking-encapsulation to refer to MQTT or "client_id" in the code to differentiate between _servers_, so the code uses the term "frigate_instance_id" (which is just the MQTT "client_id"). 

New example view URL: `/api/frigate/frigate_mqtt_client_id/front_door-1624599978.427826-976jaa.mp4`
New example media identifier: `media-source://frigate/frigate_mqtt_client_id/clip-search/.yesterday/1622678400/1622764800//`