### PR TITLE
Migrate to Frigate ConfigEntry v2

### DIFF
--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -18,6 +18,7 @@ from . import (
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
+    get_frigate_entity_unique_id,
 )
 from .const import DOMAIN, NAME, VERSION
 
@@ -75,7 +76,11 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID for this entity."""
-        return f"{DOMAIN}_{self._cam_name}_{self._obj_name}_binary_sensor"
+        return get_frigate_entity_unique_id(
+            self._config_entry.entry_id,
+            "motion_sensor",
+            f"{self._cam_name}_{self._obj_name}",
+        )
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -7,7 +7,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_URL
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
@@ -20,7 +20,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Frigate."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     async def async_step_user(
@@ -38,13 +38,13 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             # Cannot use cv.url validation in the schema itself, so
             # apply extra validation here.
-            cv.url(user_input[CONF_HOST])
+            cv.url(user_input[CONF_URL])
         except vol.Invalid:
             return self._show_config_form(user_input, errors={"base": "invalid_url"})
 
         try:
             session = async_create_clientsession(self.hass)
-            client = FrigateApiClient(user_input[CONF_HOST], session)
+            client = FrigateApiClient(user_input[CONF_URL], session)
             await client.async_get_stats()
         except FrigateApiClientError:
             return self._show_config_form(user_input, errors={"base": "cannot_connect"})
@@ -65,7 +65,7 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)
+                        CONF_URL, default=user_input.get(CONF_URL, DEFAULT_HOST)
                     ): str
                 }
             ),

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -21,6 +21,7 @@ from homeassistant.components.media_source.models import (
     MediaSourceItem,
     PlayMedia,
 )
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.template import DATE_STR_FORMAT
@@ -326,7 +327,7 @@ class FrigateMediaSource(MediaSource):
         super().__init__(DOMAIN)
         self.hass = hass
         self._client = FrigateApiClient(
-            self.hass.data[DOMAIN]["host"], async_get_clientsession(hass)
+            self.hass.data[DOMAIN][CONF_URL], async_get_clientsession(hass)
         )
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -18,6 +18,7 @@ from . import (
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
+    get_frigate_entity_unique_id,
 )
 from .const import (
     DOMAIN,
@@ -83,7 +84,9 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{DOMAIN}_detection_fps"
+        return get_frigate_entity_unique_id(
+            self._config_entry.entry_id, "sensor_fps", "detection"
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -140,7 +143,9 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{DOMAIN}_{self._detector_name}_inference_speed"
+        return get_frigate_entity_unique_id(
+            self._config_entry.entry_id, "sensor_detector_speed", self._detector_name
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -203,7 +208,11 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{DOMAIN}_{self._cam_name}_{self._fps_type}_fps"
+        return get_frigate_entity_unique_id(
+            self._config_entry.entry_id,
+            "sensor_fps",
+            f"{self._cam_name}_{self._fps_type}",
+        )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -298,7 +307,11 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{DOMAIN}_{self._cam_name}_{self._obj_name}"
+        return get_frigate_entity_unique_id(
+            self._config_entry.entry_id,
+            "sensor_object_count",
+            f"{self._cam_name}_{self._obj_name}",
+        )
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -12,7 +12,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import FrigateMQTTEntity, get_friendly_name, get_frigate_device_identifier
+from . import (
+    FrigateMQTTEntity,
+    get_friendly_name,
+    get_frigate_device_identifier,
+    get_frigate_entity_unique_id,
+)
 from .const import (
     DOMAIN,
     ICON_FILM_MULTIPLE,
@@ -90,7 +95,11 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID to use for this entity."""
-        return f"{DOMAIN}_{self._cam_name}_{self._switch_name}_switch"
+        return get_frigate_entity_unique_id(
+            self._config_entry.entry_id,
+            "switch",
+            f"{self._cam_name}_{self._switch_name}",
+        )
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -3,9 +3,9 @@
         "step": {
             "user": {
                 "title": "Frigate",
-                "description": "Host is the url you use to access Frigate (ie. `http://frigate:5000/`)\n\nIf you are using HassOS with the addon, the host should be `http://ccab4aaf-frigate:5000/`\n\nHome Assistant needs access to port 5000 (api) and 1935 (rtmp) for all features.\n\nThe integration will setup sensors, cameras, and media browser functionality.\n\nSensors:\n- Stats to monitor frigate performance\n- Object counts for all zones and cameras\n\nCameras:\n- Cameras for image of the last detected object for each camera\n- Camera entities with stream support (requires RTMP)\n\nMedia Browser:\n- Rich UI with thumbnails for browsing event clips\n- Rich UI for browsing 24/7 recordings by month, day, camera, time\n\nAPI:\n- Notification API with public facing endpoints for images in notifications",
+                "description": "URL you use to access Frigate (ie. `http://frigate:5000/`)\n\nIf you are using HassOS with the addon, the URL should be `http://ccab4aaf-frigate:5000/`\n\nHome Assistant needs access to port 5000 (api) and 1935 (rtmp) for all features.\n\nThe integration will setup sensors, cameras, and media browser functionality.\n\nSensors:\n- Stats to monitor frigate performance\n- Object counts for all zones and cameras\n\nCameras:\n- Cameras for image of the last detected object for each camera\n- Camera entities with stream support (requires RTMP)\n\nMedia Browser:\n- Rich UI with thumbnails for browsing event clips\n- Rich UI for browsing 24/7 recordings by month, day, camera, time\n\nAPI:\n- Notification API with public facing endpoints for images in notifications",
                 "data": {
-                    "host": "Host"
+                    "url": "URL"
                 }
             }
         },

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate.const import DOMAIN, NAME
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
 TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID = (
@@ -25,14 +25,14 @@ TEST_SENSOR_STEPS_PERSON_ENTITY_ID = "sensor.steps_person"
 TEST_SENSOR_FRONT_DOOR_PERSON_ENTITY_ID = "sensor.front_door_person"
 TEST_SENSOR_DETECTION_FPS_ENTITY_ID = "sensor.detection_fps"
 TEST_SENSOR_CPU1_INTFERENCE_SPEED_ENTITY_ID = "sensor.cpu1_inference_speed"
-TEST_SENSOR_CPU2_INTFERENCE_SPEED_ENTITY_ID = "sensor.cpu1_inference_speed"
+TEST_SENSOR_CPU2_INTFERENCE_SPEED_ENTITY_ID = "sensor.cpu2_inference_speed"
 TEST_SENSOR_FRONT_DOOR_CAMERA_FPS_ENTITY_ID = "sensor.front_door_camera_fps"
 TEST_SENSOR_FRONT_DOOR_DETECTION_FPS_ENTITY_ID = "sensor.front_door_detection_fps"
 TEST_SENSOR_FRONT_DOOR_PROCESS_FPS_ENTITY_ID = "sensor.front_door_process_fps"
 TEST_SENSOR_FRONT_DOOR_SKIPPED_FPS_ENTITY_ID = "sensor.front_door_skipped_fps"
 
 TEST_CONFIG_ENTRY_ID = "74565ad414754616000674c87bdc876c"
-TEST_HOST = "http://example.com"
+TEST_URL = "http://example.com"
 TEST_CONFIG = {
     "cameras": {
         "front_door": {
@@ -267,9 +267,10 @@ def create_mock_frigate_config_entry(
     config_entry: MockConfigEntry = MockConfigEntry(
         entry_id=TEST_CONFIG_ENTRY_ID,
         domain=DOMAIN,
-        data=data or {CONF_HOST: TEST_HOST},
+        data=data or {CONF_URL: TEST_URL},
         title=NAME,
         options=options or {},
+        version=2,
     )
     config_entry.add_to_hass(hass)
     return config_entry

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from . import (
     TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID,
     TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID,
+    TEST_CONFIG_ENTRY_ID,
     create_mock_frigate_client,
     setup_mock_frigate_config_entry,
 )
@@ -109,3 +110,16 @@ async def test_binary_sensor_device_info(
         for entry in er.async_entries_for_device(entity_registry, device.id)
     ]
     assert entity in entities_from_device
+
+
+async def test_binary_sensor_unique_id(hass: HomeAssistant):
+    """Verify entity unique_id(s)."""
+    await setup_mock_frigate_config_entry(hass)
+    registry_entry = er.async_get(hass).async_get(
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+    )
+    assert registry_entry
+    assert (
+        registry_entry.unique_id
+        == f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"
+    )

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
 from custom_components.frigate.const import DOMAIN, NAME, VERSION
@@ -17,6 +18,7 @@ from . import (
     TEST_CAMERA_FRONT_DOOR_ENTITY_ID,
     TEST_CAMERA_FRONT_DOOR_PERSON_ENTITY_ID,
     TEST_CONFIG,
+    TEST_CONFIG_ENTRY_ID,
     create_mock_frigate_client,
     setup_mock_frigate_config_entry,
 )
@@ -120,3 +122,24 @@ async def test_camera_device_info(hass: HomeAssistant) -> None:
     ]
     assert TEST_CAMERA_FRONT_DOOR_ENTITY_ID in entities_from_device
     assert TEST_CAMERA_FRONT_DOOR_PERSON_ENTITY_ID in entities_from_device
+
+
+@pytest.mark.parametrize(
+    "entityid_to_uniqueid",
+    [
+        (TEST_CAMERA_FRONT_DOOR_ENTITY_ID, f"{TEST_CONFIG_ENTRY_ID}:camera:front_door"),
+        (
+            TEST_CAMERA_FRONT_DOOR_PERSON_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:camera_snapshots:front_door_person",
+        ),
+    ],
+)
+async def test_camera_unique_id(entityid_to_uniqueid, hass: HomeAssistant):
+    """Verify entity unique_id(s)."""
+    entity_id, unique_id = entityid_to_uniqueid
+
+    await setup_mock_frigate_config_entry(hass)
+
+    registry_entry = er.async_get(hass).async_get(entity_id)
+    assert registry_entry
+    assert registry_entry.unique_id == unique_id

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,10 +7,10 @@ from unittest.mock import AsyncMock, patch
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import DOMAIN, NAME
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
-from . import TEST_HOST, create_mock_frigate_client, create_mock_frigate_config_entry
+from . import TEST_URL, create_mock_frigate_client, create_mock_frigate_config_entry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: TEST_HOST,
+                CONF_URL: TEST_URL,
             },
         )
         await hass.async_block_till_done()
@@ -43,7 +43,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
     assert result["type"] == "create_entry"
     assert result["title"] == NAME
     assert result["data"] == {
-        CONF_HOST: TEST_HOST,
+        CONF_URL: TEST_URL,
     }
     assert len(mock_setup_entry.mock_calls) == 1
     assert mock_client.async_get_stats.called
@@ -79,7 +79,7 @@ async def test_user_connection_failure(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: TEST_HOST,
+                CONF_URL: TEST_URL,
             },
         )
         await hass.async_block_till_done()
@@ -99,7 +99,7 @@ async def test_user_invalid_url(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_HOST: "THIS IS NOT A URL",
+            CONF_URL: "THIS IS NOT A URL",
         },
     )
     await hass.async_block_till_done()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 import logging
 from unittest.mock import AsyncMock, patch
 
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from . import create_mock_frigate_client, setup_mock_frigate_config_entry
+from . import (
+    TEST_CONFIG_ENTRY_ID,
+    create_mock_frigate_client,
+    setup_mock_frigate_config_entry,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,3 +67,89 @@ async def test_entry_async_get_config_fail(hass: HomeAssistant) -> None:
 
     config_entry = await setup_mock_frigate_config_entry(hass, client=client)
     assert config_entry.state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_entry_migration_v1_to_v2(hass: HomeAssistant) -> None:
+    """Test migrating a config entry."""
+    entity_registry = er.async_get(hass)
+
+    config_entry: MockConfigEntry = MockConfigEntry(
+        entry_id=TEST_CONFIG_ENTRY_ID,
+        domain=DOMAIN,
+        data={CONF_HOST: "http://host"},
+        title="http://host",
+        version=1,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    old_unique_ids = [
+        ("binary_sensor", "frigate_front_door_person_binary_sensor"),
+        ("camera", "frigate_front_door_camera"),
+        ("camera", "frigate_front_door_person_snapshot"),
+        ("sensor", "frigate_front_door_camera_fps"),
+        ("sensor", "frigate_front_door_person"),
+        ("sensor", "frigate_detection_fps"),
+        ("sensor", "frigate_front_door_process_fps"),
+        ("sensor", "frigate_front_door_skipped_fps"),
+        ("switch", "frigate_front_door_clips_switch"),
+        ("switch", "frigate_front_door_detect_switch"),
+        ("switch", "frigate_front_door_snapshots_switch"),
+        ("sensor", "frigate_cpu1_inference_speed"),
+        ("sensor", "frigate_cpu2_inference_speed"),
+        ("sensor", "frigate_front_door_detection_fps"),
+        ("sensor", "frigate_steps_person"),
+        ("binary_sensor", "frigate_steps_person_binary_sensor"),
+    ]
+
+    unrelated_unique_ids = [
+        ("cover", "will_match_nothing"),
+    ]
+
+    # Create fake entries with the old unique_ids.
+    for platform, unique_id in old_unique_ids + unrelated_unique_ids:
+        assert entity_registry.async_get_or_create(
+            platform, DOMAIN, unique_id, config_entry=config_entry
+        )
+
+    # Setup the integration.
+    config_entry = await setup_mock_frigate_config_entry(
+        hass, config_entry=config_entry
+    )
+
+    # Verify the config entry data is as expected.
+    assert CONF_HOST not in config_entry.data
+    assert CONF_URL in config_entry.data
+    assert config_entry.version == 2
+
+    # Ensure all the old entity unique ids are removed.
+    for platform, unique_id in old_unique_ids:
+        assert not entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
+
+    # Ensure all the unrelated entity unique ids are not touched.
+    for platform, unique_id in unrelated_unique_ids:
+        assert entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
+
+    # Ensure all the new transformed entity unique ids are present.
+    new_unique_ids = [
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"),
+        ("camera", f"{TEST_CONFIG_ENTRY_ID}:camera:front_door"),
+        ("camera", f"{TEST_CONFIG_ENTRY_ID}:camera_snapshots:front_door_person"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_camera"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_object_count:front_door_person"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:detection"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_process"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_skipped"),
+        ("switch", f"{TEST_CONFIG_ENTRY_ID}:switch:front_door_clips"),
+        ("switch", f"{TEST_CONFIG_ENTRY_ID}:switch:front_door_detect"),
+        ("switch", f"{TEST_CONFIG_ENTRY_ID}:switch:front_door_snapshots"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_detector_speed:cpu1"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_detector_speed:cpu2"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_detection"),
+        ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_object_count:steps_person"),
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:steps_person"),
+    ]
+    for platform, unique_id in new_unique_ids:
+        assert (
+            entity_registry.async_get_entity_id(platform, DOMAIN, unique_id) is not None
+        )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,6 +32,7 @@ import homeassistant.util.dt as dt_util
 
 from . import (
     TEST_CONFIG,
+    TEST_CONFIG_ENTRY_ID,
     TEST_SENSOR_CPU1_INTFERENCE_SPEED_ENTITY_ID,
     TEST_SENSOR_CPU2_INTFERENCE_SPEED_ENTITY_ID,
     TEST_SENSOR_DETECTION_FPS_ENTITY_ID,
@@ -295,3 +296,47 @@ async def test_camera_fps_sensor(hass: HomeAssistant) -> None:
     entity_state = hass.states.get(TEST_SENSOR_FRONT_DOOR_CAMERA_FPS_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "unknown"
+
+
+@pytest.mark.parametrize(
+    "entityid_to_uniqueid",
+    [
+        (
+            TEST_SENSOR_FRONT_DOOR_PERSON_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_object_count:front_door_person",
+        ),
+        (
+            TEST_SENSOR_DETECTION_FPS_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:detection",
+        ),
+        (
+            TEST_SENSOR_CPU1_INTFERENCE_SPEED_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_detector_speed:cpu1",
+        ),
+        (
+            TEST_SENSOR_FRONT_DOOR_CAMERA_FPS_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_camera",
+        ),
+        (
+            TEST_SENSOR_FRONT_DOOR_DETECTION_FPS_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_detection",
+        ),
+        (
+            TEST_SENSOR_FRONT_DOOR_PROCESS_FPS_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_process",
+        ),
+        (
+            TEST_SENSOR_FRONT_DOOR_SKIPPED_FPS_ENTITY_ID,
+            f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_skipped",
+        ),
+    ],
+)
+async def test_camera_unique_id(entityid_to_uniqueid, hass: HomeAssistant):
+    """Verify entity unique_id(s)."""
+    entity_id, unique_id = entityid_to_uniqueid
+
+    await setup_mock_frigate_config_entry(hass)
+
+    registry_entry = er.async_get(hass).async_get(entity_id)
+    assert registry_entry
+    assert registry_entry.unique_id == unique_id

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
+    TEST_CONFIG_ENTRY_ID,
     TEST_SWITCH_FRONT_DOOR_CLIPS_ENTITY_ID,
     TEST_SWITCH_FRONT_DOOR_DETECT_ENTITY_ID,
     TEST_SWITCH_FRONT_DOOR_SNAPSHOTS_ENTITY_ID,
@@ -140,3 +141,15 @@ async def test_switch_icon(hass: HomeAssistant) -> None:
         entity_state = hass.states.get(entity_id)
         assert entity_state
         assert entity_state.attributes["icon"] == icon
+
+
+async def test_switch_unique_id(hass: HomeAssistant):
+    """Verify entity unique_id(s)."""
+    await setup_mock_frigate_config_entry(hass)
+    registry_entry = er.async_get(hass).async_get(
+        TEST_SWITCH_FRONT_DOOR_DETECT_ENTITY_ID
+    )
+    assert registry_entry
+    assert (
+        registry_entry.unique_id == f"{TEST_CONFIG_ENTRY_ID}:switch:front_door_detect"
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ import aiohttp
 from aiohttp import hdrs, web
 import pytest
 
-from homeassistant.const import CONF_HOST, HTTP_NOT_FOUND, HTTP_OK
+from homeassistant.const import CONF_URL, HTTP_NOT_FOUND, HTTP_OK
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -81,7 +81,7 @@ async def hass_client_local_frigate(
 
     client = create_mock_frigate_client()
     config_entry = create_mock_frigate_config_entry(
-        hass, data={CONF_HOST: str(server.make_url("/"))}
+        hass, data={CONF_URL: str(server.make_url("/"))}
     )
     await setup_mock_frigate_config_entry(
         hass, config_entry=config_entry, client=client


### PR DESCRIPTION
   * Change the `unique_id` of all Frigate entities. This is a *major* change that risks breaking every Frigate entity and should be reviewed very carefully.
   * Use a "big-endian" unique_id scheme `<config entry id>:<class descriptor>:<entity descriptive name>`. This unique_id is internal to HomeAssistant only, and links two HomeAssistant objects (config entries and entities) -- `<config entry id>` is absolutely the right choice here IMO, despite the discussion on #91 around which URL path to use: due to the cost/complexity of changing these identifiers, they should be as "insulated" as possible. A user will never see these identifiers.
   * Attempt to do this in a backwards compatible way via a unittested config flow migration.
   * Add unittests for unique_ids.
   * While at it, address a silly nit-pick: ConfigEntries store URLs (not hosts).

Best starting point for a review is the [migration unittest](https://github.com/blakeblackshear/frigate-hass-integration/compare/master...dermotduffy:unique_id_from_config_entry?expand=1#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599e) which tests the before/after unique_ids.

Without this PR, https://github.com/blakeblackshear/frigate-hass-integration/pull/91 is not possible, so whilst it's a non-trivial change I think there's a payoff here and that the resultant `unique_ids` are more future proof.