### PR TITLE
Add a template option to allow the RTMP path to be overridden

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,
-    "python.pythonPath": "/home/dizer/.virtualenvs/hass-frigate/bin/python",
+    "python.pythonPath": "/usr/local/bin/python",
     "python.formatting.provider": "black",
     "files.associations": {
         "*.yaml": "home-assistant"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,
-    "python.pythonPath": "/usr/local/bin/python",
+    "python.pythonPath": "/home/dizer/.virtualenvs/hass-frigate/bin/python",
     "python.formatting.provider": "black",
     "files.associations": {
         "*.yaml": "home-assistant"

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import async_timeout
+from jinja2 import Template
 from yarl import URL
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
@@ -24,7 +25,15 @@ from . import (
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
 )
-from .const import ATTR_CONFIG, DOMAIN, NAME, STATE_DETECTED, STATE_IDLE, VERSION
+from .const import (
+    ATTR_CONFIG,
+    CONF_RTMP_URL_TEMPLATE,
+    DOMAIN,
+    NAME,
+    STATE_DETECTED,
+    STATE_IDLE,
+    VERSION,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -38,8 +47,8 @@ async def async_setup_entry(
 
     async_add_entities(
         [
-            FrigateCamera(entry, cam_name, camera)
-            for cam_name, camera in config["cameras"].items()
+            FrigateCamera(entry, cam_name, camera_config)
+            for cam_name, camera_config in config["cameras"].items()
         ]
         + [
             FrigateMqttSnapshots(entry, config, cam_name, obj_name)
@@ -52,19 +61,33 @@ class FrigateCamera(FrigateEntity, Camera):
     """Representation a Frigate camera."""
 
     def __init__(
-        self, config_entry: ConfigEntry, cam_name: str, config: dict[str, Any]
+        self, config_entry: ConfigEntry, cam_name: str, camera_config: dict[str, Any]
     ) -> None:
         """Initialize a Frigate camera."""
         FrigateEntity.__init__(self, config_entry)
         Camera.__init__(self)
         self._cam_name = cam_name
-        self._config = config
+        self._camera_config = camera_config
         self._url = config_entry.data[CONF_URL]
         self._latest_url = str(
             URL(self._url) / f"api/{self._cam_name}/latest.jpg" % {"h": 277}
         )
-        self._stream_source = f"rtmp://{URL(self._url).host}/live/{self._cam_name}"
-        self._stream_enabled = self._config["rtmp"]["enabled"]
+        self._stream_enabled = self._camera_config["rtmp"]["enabled"]
+
+        streaming_template = config_entry.options.get(
+            CONF_RTMP_URL_TEMPLATE, ""
+        ).strip()
+
+        if streaming_template:
+            # Can't use homeassistant.helpers.template as it requires hass which
+            # is not available in the constructior, so use direct jinja2
+            # template instead. This means templates cannot access HomeAssistant
+            # state, but rather only the camera config.
+            self._stream_source = Template(streaming_template).render(
+                **self._camera_config
+            )
+        else:
+            self._stream_source = f"rtmp://{URL(self._url).host}/live/{self._cam_name}"
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -80,7 +80,7 @@ class FrigateCamera(FrigateEntity, Camera):
 
         if streaming_template:
             # Can't use homeassistant.helpers.template as it requires hass which
-            # is not available in the constructior, so use direct jinja2
+            # is not available in the constructor, so use direct jinja2
             # template instead. This means templates cannot access HomeAssistant
             # state, but rather only the camera config.
             self._stream_source = Template(streaming_template).render(

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -34,6 +34,9 @@ ATTR_COORDINATOR = "coordinator"
 ATTR_MQTT = "mqtt"
 ATTR_CLIENT_ID = "client_id"
 
+# Configuration and options
+CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
+
 # Defaults
 DEFAULT_NAME = DOMAIN
 DEFAULT_HOST = "http://ccab4aaf-frigate:5000"

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -16,5 +16,14 @@
         "abort": {
             "already_configured": "Device is already configured"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "rtmp_url_template": "RTMP URL template (see documentation)"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Add an advanced option for the integration, that allows the RTMP path to be overriden. This could be useful if the RTMP port is a different value, or is running behind a reverse proxy. The template supports access to the Frigate camera configuration, so for example a value like:

```rtmp://host.wherever:9999/live/{{ name }}```

... would access the camera name.

A simpler version of this would just be to support setting a different port, but I think this is more extensible. This effectively replaces https://github.com/blakeblackshear/frigate-hass-integration/pull/32 .