### PR TITLE
Add strict type checking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: Build
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,10 @@ repos:
         language: system
         types: [python]
         args: ["--errors-only"]
+      - id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        require_serial: true
+        files: ^(custom_components/frigate|tests)/.+\.py$

--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
+from typing import Any, Dict, List, cast
 
 import aiohttp
 import async_timeout
@@ -34,19 +35,22 @@ class FrigateApiClient:
         self._host = host
         self._session = session
 
-    async def async_get_stats(self) -> dict:
+    async def async_get_stats(self) -> dict[str, Any]:
         """Get data from the API."""
-        return await self.api_wrapper("get", str(URL(self._host) / "api/stats"))
+        return cast(
+            Dict[str, Any],
+            await self.api_wrapper("get", str(URL(self._host) / "api/stats")),
+        )
 
     async def async_get_events(
         self,
-        camera=None,
-        label=None,
-        zone=None,
-        after=None,
-        before=None,
-        limit: int = None,
-    ) -> dict:
+        camera: str | None = None,
+        label: str | None = None,
+        zone: str | None = None,
+        after: int | None = None,
+        before: int | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         """Get data from the API."""
         params = {
             "camera": camera,
@@ -58,24 +62,35 @@ class FrigateApiClient:
             "has_clip": 1,
         }
 
-        return await self.api_wrapper(
-            "get",
-            str(
-                URL(self._host) / "api/events" % {k: v for k, v in params.items() if v}
+        return cast(
+            List[Dict[str, Any]],
+            await self.api_wrapper(
+                "get",
+                str(
+                    URL(self._host)
+                    / "api/events"
+                    % {k: v for k, v in params.items() if v}
+                ),
             ),
         )
 
-    async def async_get_event_summary(self) -> dict:
+    async def async_get_event_summary(self) -> list[dict[str, Any]]:
         """Get data from the API."""
-        return await self.api_wrapper(
-            "get", str(URL(self._host) / "api/events/summary" % {"has_clip": 1})
+        return cast(
+            List[Dict[str, Any]],
+            await self.api_wrapper(
+                "get", str(URL(self._host) / "api/events/summary" % {"has_clip": 1})
+            ),
         )
 
-    async def async_get_config(self) -> dict:
+    async def async_get_config(self) -> dict[str, Any]:
         """Get data from the API."""
-        return await self.api_wrapper("get", str(URL(self._host) / "api/config"))
+        return cast(
+            Dict[str, Any],
+            await self.api_wrapper("get", str(URL(self._host) / "api/config")),
+        )
 
-    async def async_get_path(self, path) -> dict:
+    async def async_get_path(self, path: str) -> Any:
         """Get data from the API."""
         return await self.api_wrapper("get", str(URL(self._host) / f"{path}/"))
 
@@ -85,7 +100,7 @@ class FrigateApiClient:
         url: str,
         data: dict | None = None,
         headers: dict | None = None,
-    ) -> dict:
+    ) -> Any:
         """Get information from the API."""
         if data is None:
             data = {}

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
@@ -38,7 +38,7 @@ async def async_setup_entry(
     )
 
 
-class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):
+class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]
     """Frigate Motion Sensor class."""
 
     def __init__(
@@ -64,7 +64,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):
             },
         )
 
-    @callback
+    @callback  # type: ignore[misc]
     def _state_message_received(self, msg: Message) -> None:
         """Handle a new received MQTT state message."""
         try:
@@ -108,4 +108,4 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):
     @property
     def device_class(self) -> str:
         """Return the device class."""
-        return DEVICE_CLASS_MOTION
+        return cast(str, DEVICE_CLASS_MOTION)

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):
+class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Sensor class."""
 
     def __init__(
@@ -128,7 +128,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):
         return ICON_SPEEDOMETER
 
 
-class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):
+class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Detector Speed class."""
 
     def __init__(
@@ -191,7 +191,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):
         return ICON_SPEEDOMETER
 
 
-class CameraFpsSensor(FrigateEntity, CoordinatorEntity):
+class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Camera Fps class."""
 
     def __init__(
@@ -297,7 +297,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
             },
         )
 
-    @callback
+    @callback  # type: ignore[misc]
     def _state_message_received(self, msg: Message) -> None:
         """Handle a new received MQTT state message."""
         try:

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
+class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
     """Frigate Switch class."""
 
     def __init__(
@@ -87,7 +87,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
             },
         )
 
-    @callback
+    @callback  # type: ignore[misc]
     def _state_message_received(self, msg: Message) -> None:
         """Handle a new received MQTT state message."""
         self._is_on = msg.payload == "ON"
@@ -125,7 +125,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
         """Return true if the binary sensor is on."""
         return self._is_on
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         async_publish(
             self.hass,
@@ -135,7 +135,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
             True,
         )
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         async_publish(
             self.hass,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,26 @@ norecursedirs = [
     "testing_config",
 ]
 addopts = "--timeout=10 --cov-report=xml:coverage.xml --cov-report=term-missing --cov=custom_components.frigate --cov-fail-under=100"
+
+[tool.mypy]
+# Stock HomeAssistant mypy configuration.
+ignore_missing_imports = true
+python_version = "3.8"
+follow_imports = "silent"
+strict_equality = true
+warn_incomplete_stub = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
+# Custom Frigate configuration.
+show_error_codes = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 aiohttp_cors==0.7.0
 attr
 homeassistant==2021.6.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,11 @@
 -r requirements.txt
 black
 flake8
+mymy
 pre-commit
 pytest==6.2.4
 pytest-homeassistant-custom-component==0.4.1
 pylint-pytest
 pylint==2.8.3
 pytest-aiohttp==0.3.0
+types-python-dateutil

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 black
 flake8
-mymy
+mypy==0.910
 pre-commit
 pytest==6.2.4
 pytest-homeassistant-custom-component==0.4.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -243,7 +243,9 @@ TEST_EVENT_SUMMARY = [
 ]
 
 
-async def start_frigate_server(aiohttp_server: Any, handlers: list[web.route]) -> Any:
+async def start_frigate_server(
+    aiohttp_server: Any, handlers: list[web.RouteDef]
+) -> Any:
     """Start a fake Frigate server."""
     app = web.Application()
     app.add_routes(handlers)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncGenerator
 import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
 import aiohttp
-from aiohttp import web  # type: ignore
+from aiohttp import web
 import pytest
 
 from custom_components.frigate.api import FrigateApiClient, FrigateApiClientError
@@ -24,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture
-async def aiohttp_session() -> aiohttp.ClientSession:
+async def aiohttp_session() -> AsyncGenerator[aiohttp.ClientSession, None]:
     """Test fixture for aiohttp.ClientSerssion."""
     async with aiohttp.ClientSession() as session:
         yield session
@@ -81,9 +82,9 @@ async def test_async_get_events(
                 "camera": "test_camera",
                 "label": "test_label",
                 "zone": "test_zone",
-                "after": "test_after",
-                "before": "test_before",
-                "limit": "test_limit",
+                "after": "1",
+                "before": "2",
+                "limit": "3",
                 "has_clip": "1",
             },
         )
@@ -98,9 +99,9 @@ async def test_async_get_events(
         camera="test_camera",
         label="test_label",
         zone="test_zone",
-        after="test_after",
-        before="test_before",
-        limit="test_limit",
+        after=1,
+        before=2,
+        limit=3,
     )
 
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -112,7 +112,7 @@ async def test_binary_sensor_device_info(
     assert entity in entities_from_device
 
 
-async def test_binary_sensor_unique_id(hass: HomeAssistant):
+async def test_binary_sensor_unique_id(hass: HomeAssistant) -> None:
     """Verify entity unique_id(s)."""
     await setup_mock_frigate_config_entry(hass)
     registry_entry = er.async_get(hass).async_get(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -62,7 +62,7 @@ async def test_frigate_camera_setup(
 async def test_frigate_camera_setup_no_stream(hass: HomeAssistant) -> None:
     """Set up a camera without streaming."""
 
-    config = copy.deepcopy(TEST_CONFIG)
+    config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     config["cameras"]["front_door"]["rtmp"]["enabled"] = False
     client = create_mock_frigate_client()
     client.async_get_config = AsyncMock(return_value=config)
@@ -140,7 +140,9 @@ async def test_camera_device_info(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_camera_unique_id(entityid_to_uniqueid, hass: HomeAssistant):
+async def test_camera_unique_id(
+    entityid_to_uniqueid: tuple[str, str], hass: HomeAssistant
+) -> None:
     """Verify entity unique_id(s)."""
     entity_id, unique_id = entityid_to_uniqueid
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -98,10 +98,12 @@ async def test_object_count_sensor(hass: HomeAssistant) -> None:
         ("SOMETHING_ELSE", ICON_OTHER),
     ],
 )
-async def test_object_count_icon(object_icon, hass: HomeAssistant) -> None:
+async def test_object_count_icon(
+    object_icon: tuple[str, str], hass: HomeAssistant
+) -> None:
     """Test FrigateObjectCountSensor car icon."""
     object, icon = object_icon
-    config = copy.deepcopy(TEST_CONFIG)
+    config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     config["cameras"]["front_door"]["objects"]["track"] = [object]
     client = create_mock_frigate_client()
     client.async_get_config = AsyncMock(return_value=config)
@@ -230,7 +232,7 @@ async def test_detector_speed_sensor(hass: HomeAssistant) -> None:
     assert entity_state.attributes["icon"] == ICON_SPEEDOMETER
     assert entity_state.attributes["unit_of_measurement"] == MS
 
-    stats = copy.deepcopy(TEST_STATS)
+    stats: dict[str, Any] = copy.deepcopy(TEST_STATS)
     client.async_get_stats = AsyncMock(return_value=stats)
 
     stats["detectors"]["cpu1"]["inference_speed"] = 11.5
@@ -270,7 +272,7 @@ async def test_camera_fps_sensor(hass: HomeAssistant) -> None:
     assert entity_state.attributes["icon"] == ICON_SPEEDOMETER
     assert entity_state.attributes["unit_of_measurement"] == FPS
 
-    stats = copy.deepcopy(TEST_STATS)
+    stats: dict[str, Any] = copy.deepcopy(TEST_STATS)
     client.async_get_stats = AsyncMock(return_value=stats)
 
     stats["front_door"]["camera_fps"] = 3.9
@@ -331,7 +333,9 @@ async def test_camera_fps_sensor(hass: HomeAssistant) -> None:
         ),
     ],
 )
-async def test_camera_unique_id(entityid_to_uniqueid, hass: HomeAssistant):
+async def test_camera_unique_id(
+    entityid_to_uniqueid: tuple[str, str], hass: HomeAssistant
+) -> None:
     """Verify entity unique_id(s)."""
     entity_id, unique_id = entityid_to_uniqueid
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -143,7 +143,7 @@ async def test_switch_icon(hass: HomeAssistant) -> None:
         assert entity_state.attributes["icon"] == icon
 
 
-async def test_switch_unique_id(hass: HomeAssistant):
+async def test_switch_unique_id(hass: HomeAssistant) -> None:
     """Verify entity unique_id(s)."""
     await setup_mock_frigate_config_entry(hass)
     registry_entry = er.async_get(hass).async_get(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -36,11 +36,11 @@ class FakeStreamResponse(web.StreamResponse):
 class FakeAsyncContextManager:
     """Fake AsyncContextManager for testing purposes."""
 
-    async def __aenter__(self, *args, **kwargs):
+    async def __aenter__(self, *args: Any, **kwargs: Any) -> FakeAsyncContextManager:
         """Context manager enter."""
         return self
 
-    async def __aexit__(self, *args, **kwargs):
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         """Context manager exit."""
 
 


### PR DESCRIPTION
   * Make code "mypy clean": Didn't find anything major broken, but several incorrect/missing type annotations.
   * Use ~stock Home Assistant Core mypy configuration (as Home Assistant doesn't offer type hints to custom integrations, this requires some mypy warnings to be explicitly marked ignored, e.g. inheriting from an untyped class).
   * Have pre-commit run mypy by default.