### PR TITLE
Version improvements

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -15,7 +15,7 @@ from custom_components.frigate.config_flow import get_config_entry_title
 from homeassistant.components.mqtt.models import Message
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_URL
+from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL
 from homeassistant.core import Config, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
@@ -111,14 +111,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     try:
+        server_version = await client.async_get_version()
         config = await client.async_get_config()
     except FrigateApiClientError as exc:
         raise ConfigEntryNotReady from exc
+
+    model = f"{(await async_get_integration(hass, DOMAIN)).version}/{server_version}"
 
     hass.data[DOMAIN][entry.entry_id] = {
         ATTR_COORDINATOR: coordinator,
         ATTR_CLIENT: client,
         ATTR_CONFIG: config,
+        ATTR_MODEL: model,
     }
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
@@ -239,6 +243,10 @@ class FrigateEntity(Entity):
     def available(self) -> bool:
         """Return the availability of the entity."""
         return self._available
+
+    def _get_model(self) -> str:
+        """Get the Frigate device model string."""
+        return self.hass.data[DOMAIN][self._config_entry.entry_id][ATTR_MODEL]
 
 
 class FrigateMQTTEntity(FrigateEntity):

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify
 
 from .api import FrigateApiClient, FrigateApiClientError
@@ -30,6 +31,7 @@ from .const import (
     ATTR_CONFIG,
     ATTR_COORDINATOR,
     DOMAIN,
+    NAME,
     PLATFORMS,
     STARTUP_MESSAGE,
 )
@@ -84,7 +86,13 @@ def get_cameras_zones_and_objects(config: dict[str, Any]) -> {(str, str)}:
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up this integration using YAML is not supported."""
-    _LOGGER.info(STARTUP_MESSAGE)
+    integration = await async_get_integration(hass, DOMAIN)
+    _LOGGER.info(
+        STARTUP_MESSAGE.format(
+            title=NAME,
+            integration_version=integration.version,
+        )
+    )
 
     hass.data.setdefault(DOMAIN, {})
 

--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -34,6 +34,12 @@ class FrigateApiClient:
         self._host = host
         self._session = session
 
+    async def async_get_version(self) -> str:
+        """Get data from the API."""
+        return await self.api_wrapper(
+            "get", str(URL(self._host) / "api/version"), decode_json=False
+        )
+
     async def async_get_stats(self) -> dict:
         """Get data from the API."""
         return await self.api_wrapper("get", str(URL(self._host) / "api/stats"))
@@ -85,6 +91,7 @@ class FrigateApiClient:
         url: str,
         data: dict | None = None,
         headers: dict | None = None,
+        decode_json: bool = True,
     ) -> dict:
         """Get information from the API."""
         if data is None:
@@ -98,7 +105,9 @@ class FrigateApiClient:
                     response = await self._session.get(
                         url, headers=headers, raise_for_status=True
                     )
-                    return await response.json()
+                    if decode_json:
+                        return await response.json()
+                    return await response.text()
 
                 if method == "put":
                     await self._session.put(url, headers=headers, json=data)

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -20,7 +20,7 @@ from . import (
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
 )
-from .const import ATTR_CONFIG, DOMAIN, NAME, VERSION
+from .const import ATTR_CONFIG, DOMAIN, NAME
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):
             },
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -32,7 +32,6 @@ from .const import (
     NAME,
     STATE_DETECTED,
     STATE_IDLE,
-    VERSION,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -112,7 +111,7 @@ class FrigateCamera(FrigateEntity, Camera):
             },
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 
@@ -191,7 +190,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, Camera):
             },
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -3,8 +3,6 @@
 NAME = "Frigate"
 DOMAIN = "frigate"
 VERSION = "0.0.1"
-ISSUE_URL = "https://github.com/blakeblackshear/frigate-hass-integration/issues"
-
 # Icons
 ICON_CAR = "mdi:shield-car"
 ICON_CAT = "mdi:cat"
@@ -42,13 +40,13 @@ DEFAULT_NAME = DOMAIN
 DEFAULT_HOST = "http://ccab4aaf-frigate:5000"
 
 
-STARTUP_MESSAGE = f"""
+STARTUP_MESSAGE = """
 -------------------------------------------------------------------
-{NAME}
-Version: {VERSION}
+{title}
+Integration Version: {integration_version}
 This is a custom integration!
 If you have any issues with this you need to open an issue here:
-{ISSUE_URL}
+https://github.com/blakeblackshear/frigate-hass-integration/issues
 -------------------------------------------------------------------
 """
 

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -2,7 +2,7 @@
 # Base component constants
 NAME = "Frigate"
 DOMAIN = "frigate"
-VERSION = "0.0.1"
+
 # Icons
 ICON_CAR = "mdi:shield-car"
 ICON_CAT = "mdi:cat"

--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -2,7 +2,7 @@
     "domain": "frigate",
     "documentation": "https://github.com/blakeblackshear/frigate",
     "name": "Frigate",
-    "version": "1.0.4",
+    "version": "1.0.6",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "dependencies": [
         "http",

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -33,7 +33,6 @@ from .const import (
     ICON_SPEEDOMETER,
     MS,
     NAME,
-    VERSION,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -96,7 +95,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):
         return {
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 
@@ -155,7 +154,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):
         return {
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 
@@ -225,7 +224,7 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):
             },
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 
@@ -325,7 +324,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
             },
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -25,7 +25,6 @@ from .const import (
     ICON_IMAGE_MULTIPLE,
     ICON_MOTION_SENSOR,
     NAME,
-    VERSION,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -111,7 +110,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
             },
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
-            "model": VERSION,
+            "model": self._get_model(),
             "manufacturer": NAME,
         }
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,6 +31,7 @@ TEST_SENSOR_FRONT_DOOR_DETECTION_FPS_ENTITY_ID = "sensor.front_door_detection_fp
 TEST_SENSOR_FRONT_DOOR_PROCESS_FPS_ENTITY_ID = "sensor.front_door_process_fps"
 TEST_SENSOR_FRONT_DOOR_SKIPPED_FPS_ENTITY_ID = "sensor.front_door_skipped_fps"
 
+TEST_SERVER_VERSION = "0.8.4-09a4d6d"
 TEST_CONFIG_ENTRY_ID = "74565ad414754616000674c87bdc876c"
 TEST_URL = "http://example.com"
 TEST_FRIGATE_INSTANCE_ID = "frigate_client_id"
@@ -256,6 +257,7 @@ def create_mock_frigate_client() -> AsyncMock:
     mock_client.async_get_stats = AsyncMock(return_value=TEST_STATS)
     mock_client.async_get_config = AsyncMock(return_value=TEST_CONFIG)
     mock_client.async_get_event_summary = AsyncMock(return_value=TEST_EVENT_SUMMARY)
+    mock_client.async_get_version = AsyncMock(return_value=TEST_SERVER_VERSION)
     return mock_client
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ import pytest
 
 from custom_components.frigate.api import FrigateApiClient, FrigateApiClientError
 
-from . import start_frigate_server
+from . import TEST_SERVER_VERSION, start_frigate_server
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -235,3 +235,20 @@ async def test_api_wrapper_exceptions(
             await frigate_client.api_wrapper(method="get", url=server.make_url("/get"))
             assert "Error fetching information" in caplog.text
     caplog.clear()
+
+
+async def test_async_get_version(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_version."""
+
+    async def version_handler(request: web.Request) -> web.Response:
+        """Events summary handler."""
+        return web.Response(text=TEST_SERVER_VERSION)
+
+    server = await start_frigate_server(
+        aiohttp_server, [web.get("/api/version", version_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert TEST_SERVER_VERSION == await frigate_client.async_get_version()

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
 from custom_components.frigate.api import FrigateApiClientError
-from custom_components.frigate.const import DOMAIN, NAME, VERSION
+from custom_components.frigate.const import DOMAIN, NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -17,6 +17,7 @@ from . import (
     TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID,
     TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID,
     TEST_CONFIG_ENTRY_ID,
+    TEST_SERVER_VERSION,
     create_mock_frigate_client,
     setup_mock_frigate_config_entry,
 )
@@ -103,7 +104,7 @@ async def test_binary_sensor_device_info(
     )
     assert device
     assert device.manufacturer == NAME
-    assert device.model == VERSION
+    assert device.model.endswith(f"/{TEST_SERVER_VERSION}")
 
     entities_from_device = [
         entry.entity_id

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -9,12 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
-from custom_components.frigate.const import (
-    CONF_RTMP_URL_TEMPLATE,
-    DOMAIN,
-    NAME,
-    VERSION,
-)
+from custom_components.frigate.const import CONF_RTMP_URL_TEMPLATE, DOMAIN, NAME
 from homeassistant.components.camera import async_get_image, async_get_stream_source
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -24,6 +19,7 @@ from . import (
     TEST_CAMERA_FRONT_DOOR_PERSON_ENTITY_ID,
     TEST_CONFIG,
     TEST_CONFIG_ENTRY_ID,
+    TEST_SERVER_VERSION,
     create_mock_frigate_client,
     create_mock_frigate_config_entry,
     setup_mock_frigate_config_entry,
@@ -120,7 +116,7 @@ async def test_camera_device_info(hass: HomeAssistant) -> None:
     )
     assert device
     assert device.manufacturer == NAME
-    assert device.model == VERSION
+    assert device.model.endswith(f"/{TEST_SERVER_VERSION}")
 
     entities_from_device = [
         entry.entity_id

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -12,6 +13,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.loader import async_get_integration
 
 from . import (
     TEST_CONFIG_ENTRY_ID,
@@ -154,3 +156,13 @@ async def test_entry_migration_v1_to_v2(hass: HomeAssistant) -> None:
         assert (
             entity_registry.async_get_entity_id(platform, DOMAIN, unique_id) is not None
         )
+
+
+async def test_startup_message(caplog: Any, hass: HomeAssistant) -> None:
+    """Test the startup message."""
+
+    await setup_mock_frigate_config_entry(hass)
+
+    integration = await async_get_integration(hass, DOMAIN)
+    assert integration.version in caplog.text
+    assert "This is a custom integration" in caplog.text

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,7 +24,6 @@ from custom_components.frigate.const import (
     ICON_SPEEDOMETER,
     MS,
     NAME,
-    VERSION,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -42,6 +41,7 @@ from . import (
     TEST_SENSOR_FRONT_DOOR_PROCESS_FPS_ENTITY_ID,
     TEST_SENSOR_FRONT_DOOR_SKIPPED_FPS_ENTITY_ID,
     TEST_SENSOR_STEPS_PERSON_ENTITY_ID,
+    TEST_SERVER_VERSION,
     TEST_STATS,
     create_mock_frigate_client,
     setup_mock_frigate_config_entry,
@@ -146,7 +146,7 @@ async def test_per_camerazone_device_info(
     )
     assert device
     assert device.manufacturer == NAME
-    assert device.model == VERSION
+    assert device.model.endswith(f"/{TEST_SERVER_VERSION}")
 
     entities_from_device = {
         entry.entity_id
@@ -207,7 +207,7 @@ async def test_per_entry_device_info(hass: HomeAssistant) -> None:
     )
     assert device
     assert device.manufacturer == NAME
-    assert device.model == VERSION
+    assert device.model.endswith(f"/{TEST_SERVER_VERSION}")
 
     entities_from_device = [
         entry.entity_id

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
 
-from custom_components.frigate.const import DOMAIN, NAME, VERSION
+from custom_components.frigate.const import DOMAIN, NAME
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
@@ -14,6 +14,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     TEST_CONFIG_ENTRY_ID,
+    TEST_SERVER_VERSION,
     TEST_SWITCH_FRONT_DOOR_CLIPS_ENTITY_ID,
     TEST_SWITCH_FRONT_DOOR_DETECT_ENTITY_ID,
     TEST_SWITCH_FRONT_DOOR_SNAPSHOTS_ENTITY_ID,
@@ -116,7 +117,7 @@ async def test_switch_device_info(hass: HomeAssistant) -> None:
     )
     assert device
     assert device.manufacturer == NAME
-    assert device.model == VERSION
+    assert device.model.endswith(f"/{TEST_SERVER_VERSION}")
 
     entity_registry = await er.async_get_registry(hass)
     entities_from_device = [


### PR DESCRIPTION
   * Remove the old VERSION const.
   * Get the version number from the manifest (output that in the startup message)
   * Get the version number from the server, and include both integration and server version in the device info for Frigate devices.
   * Update the existing manifest version to 1.0.6 which is currently erroneously at 1.0.4.