### PR TITLE
Add an option to disable the unauthenticated notifications proxy

### DIFF
--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -14,7 +14,12 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import FrigateApiClient, FrigateApiClientError
-from .const import CONF_RTMP_URL_TEMPLATE, DEFAULT_HOST, DOMAIN
+from .const import (
+    CONF_NOTIFICATION_PROXY_ENABLE,
+    CONF_RTMP_URL_TEMPLATE,
+    DEFAULT_HOST,
+    DOMAIN,
+)
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -122,18 +127,25 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
         schema: dict[Any, Any] = {}
 
         if self.show_advanced_options:
-            # The input URL is not validated as being a URL to allow for the
-            # possibility the template input won't be a valid URL until after
-            # it's rendered.
             schema.update(
                 {
-                    vol.Required(
+                    # The input URL is not validated as being a URL to allow for the
+                    # possibility the template input won't be a valid URL until after
+                    # it's rendered.
+                    vol.Optional(
                         CONF_RTMP_URL_TEMPLATE,
                         default=self._config_entry.options.get(
                             CONF_RTMP_URL_TEMPLATE,
                             "",
                         ),
                     ): str,
+                    vol.Optional(
+                        CONF_NOTIFICATION_PROXY_ENABLE,
+                        default=self._config_entry.options.get(
+                            CONF_NOTIFICATION_PROXY_ENABLE,
+                            True,
+                        ),
+                    ): bool,
                 }
             )
 

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -36,6 +36,7 @@ ATTR_CLIENT_ID = "client_id"
 
 # Configuration and options
 CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
+CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -21,7 +21,8 @@
         "step": {
             "init": {
                 "data": {
-                    "rtmp_url_template": "RTMP URL template (see documentation)"
+                    "rtmp_url_template": "RTMP URL template (see documentation)",
+                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy"
                 }
             }
         }

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -15,12 +15,18 @@ from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_CONFIG,
     ATTR_MQTT,
+    CONF_NOTIFICATION_PROXY_ENABLE,
     DOMAIN,
 )
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_HASS
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL, HTTP_BAD_REQUEST, HTTP_NOT_FOUND
+from homeassistant.const import (
+    CONF_URL,
+    HTTP_BAD_REQUEST,
+    HTTP_FORBIDDEN,
+    HTTP_NOT_FOUND,
+)
 from homeassistant.core import HomeAssistant
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -81,25 +87,24 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
         """Initialize the frigate clips proxy view."""
         self._websession = websession
 
-    def _get_base_url(
+    def _get_config_entry_for_request(
         self, request: web.Request, frigate_instance_id: str | None
     ) -> str | None:
-        """Get a Frigate base URL."""
+        """Get a ConfigEntry for a given request."""
         hass = request.app[KEY_HASS]
 
         entry = None
         if frigate_instance_id:
-            entry = get_config_entry_for_frigate_instance_id(hass, frigate_instance_id)
-        else:
-            entry = get_default_config_entry(hass)
-
-        if entry:
-            return cast(str, entry.data[CONF_URL])
-        return None
+            return get_config_entry_for_frigate_instance_id(hass, frigate_instance_id)
+        return get_default_config_entry(hass)
 
     def _create_path(self, path: str, **kwargs: Any) -> str | None:
         """Create path."""
         raise NotImplementedError  # pragma: no cover
+
+    def _permit_request(self, request: web.Request, config_entry: ConfigEntry) -> bool:
+        """Determine whether to permit a request."""
+        return True
 
     async def get(
         self,
@@ -123,15 +128,18 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
         **kwargs: Any,
     ) -> web.Response | web.StreamResponse:
         """Handle route for request."""
-        base_url = self._get_base_url(request, frigate_instance_id)
-        if not base_url:
+        config_entry = self._get_config_entry_for_request(request, frigate_instance_id)
+        if not config_entry:
             return web.Response(status=HTTP_BAD_REQUEST)
 
-        full_path = self._create_path(path=path, **kwargs)
-        if not full_path:
+        if not self._permit_request(request, config_entry):
+            return web.Response(status=HTTP_FORBIDDEN)
+
+        path = self._create_path(path=path, **kwargs)
+        if not path:
             return web.Response(status=HTTP_NOT_FOUND)
 
-        url = str(URL(base_url) / full_path)
+        url = str(URL(config_entry.data[CONF_URL]) / path)
         data = await request.read()
         source_header = _init_header(request)
 
@@ -208,6 +216,10 @@ class NotificationsProxyView(ProxyView):
         if path.endswith("clip.mp4"):
             return f"clips/{camera}-{event_id}.mp4"
         return None
+
+    def _permit_request(self, request: web.Request, config_entry: ConfigEntry) -> bool:
+        """Determine whether to permit a request."""
+        return config_entry.options.get(CONF_NOTIFICATION_PROXY_ENABLE, True)
 
 
 def _init_header(request: web.Request) -> CIMultiDict | dict[str, str]:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate.api import FrigateApiClientError
-from custom_components.frigate.const import CONF_RTMP_URL_TEMPLATE, DOMAIN
+from custom_components.frigate.const import (
+    CONF_NOTIFICATION_PROXY_ENABLE,
+    CONF_RTMP_URL_TEMPLATE,
+    DOMAIN,
+)
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
@@ -169,8 +173,10 @@ async def test_advanced_options(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input={
                 CONF_RTMP_URL_TEMPLATE: "http://moo",
+                CONF_NOTIFICATION_PROXY_ENABLE: False,
             },
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_RTMP_URL_TEMPLATE] == "http://moo"
+        assert not result["data"][CONF_NOTIFICATION_PROXY_ENABLE]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -319,7 +319,7 @@ async def test_notifications_with_disabled_option(
         data=hass.config_entries.async_get_entry(TEST_CONFIG_ENTRY_ID).data,
     )
 
-    private_config = copy.deepcopy(TEST_CONFIG)
+    private_config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     private_config[ATTR_MQTT][ATTR_CLIENT_ID] = "private_id"
     private_client = create_mock_frigate_client()
     private_client.async_get_config = AsyncMock(return_value=private_config)


### PR DESCRIPTION
- Add an option to reject requests to the notifications proxy, to eliminate any potential privacy issues (as small as the chances of guessing an event-id would be).
- Resolves: https://github.com/blakeblackshear/frigate-hass-integration/issues/44
- Does not disable the `/clips/` and `/recordings/` endpoints, as they are authenticated.

This also fixes a bug that required the RTML_URL_TEMPLATE option to be set to a non-empty value. Once set, the HA frontend would not allow it to be unset.