### PR TITLE
Do not set host header on proxied requests

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -221,6 +221,7 @@ def _init_header(request: web.Request) -> CIMultiDict | dict[str, str]:
             hdrs.SEC_WEBSOCKET_PROTOCOL,
             hdrs.SEC_WEBSOCKET_VERSION,
             hdrs.SEC_WEBSOCKET_KEY,
+            hdrs.HOST,
         ):
             continue
         headers[name] = value


### PR DESCRIPTION
Ran into a weird problem when I used an SSL reverse-proxy in front of my setup, a HTTP 421 (had to look it up: "421 Misdirected Request") =>
   * When I make the request to the proxied URLs, the host header is for the Home Assistant instance.
   * This then get copied into the outbound request for Frigate, which the reverse-proxy then compares against the SSL cert intended for use in front of Frigate -- and finds they don't match -- and returns 421.

Do not explicitly override the host header, leave it unset.