### PR TITLE
Add an option to allow specifying camera static image size

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -131,7 +131,9 @@ class FrigateCamera(FrigateEntity, Camera):  # type: ignore[misc]
         )
 
         image_url = str(
-            URL(self._url) / f"api/{self._cam_name}/latest.jpg" % {"h": height}
+            URL(self._url)
+            / f"api/{self._cam_name}/latest.jpg"
+            % ({"h": height} if height > 0 else {})
         )
 
         with async_timeout.timeout(10):

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -133,7 +133,7 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                     CONF_CAMERA_STATIC_IMAGE_HEIGHT,
                     DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT,
                 ),
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            ): vol.All(vol.Coerce(int), vol.Range(min=0)),
         }
 
         if self.show_advanced_options:

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -15,8 +15,10 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
+    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_RTMP_URL_TEMPLATE,
+    DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT,
     DEFAULT_HOST,
     DOMAIN,
 )
@@ -124,7 +126,15 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                 Dict[str, Any], self.async_create_entry(title="", data=user_input)
             )
 
-        schema: dict[Any, Any] = {}
+        schema: dict[Any, Any] = {
+            vol.Optional(
+                CONF_CAMERA_STATIC_IMAGE_HEIGHT,
+                default=self._config_entry.options.get(
+                    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
+                    DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT,
+                ),
+            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        }
 
         if self.show_advanced_options:
             schema.update(

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -33,10 +33,12 @@ ATTR_MQTT = "mqtt"
 ATTR_CLIENT_ID = "client_id"
 
 # Configuration and options
-CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
+CONF_CAMERA_STATIC_IMAGE_HEIGHT = "camera_image_height"
 CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
+CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
 
 # Defaults
+DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT = 277
 DEFAULT_NAME = DOMAIN
 DEFAULT_HOST = "http://ccab4aaf-frigate:5000"
 

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -23,7 +23,7 @@
                 "data": {
                     "rtmp_url_template": "RTMP URL template (see documentation)",
                     "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
-                    "camera_image_height": "Height of live camera static images. Lower loads faster."
+                    "camera_image_height": "Height of live camera static images. 0 for camera default."
                 }
             }
         }

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -22,7 +22,8 @@
             "init": {
                 "data": {
                     "rtmp_url_template": "RTMP URL template (see documentation)",
-                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy"
+                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
+                    "camera_image_height": "Height of live camera static images. Lower loads faster."
                 }
             }
         }


### PR DESCRIPTION
 - Add an option to allow the user to specify the height of their live camera static snapshots, vs the default of 277. A value of 0 will not specify any value in the request to Frigate, which appears to return the camera default.
 - Resolves: https://github.com/blakeblackshear/frigate-hass-integration/issues/19