### PR TITLE
Cleanly handle connection resets

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -163,6 +163,9 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
 
             except (aiohttp.ClientError, aiohttp.ClientPayloadError) as err:
                 _LOGGER.debug("Stream error for %s: %s", request.rel_url, err)
+            except ConnectionResetError:
+                # Connection is reset/closed by peer.
+                pass
 
             return response
 


### PR DESCRIPTION
When viewing clips  an occasional "ConnectionResetError: Cannot write to closing transport" spams  the logs. Cleanly catch and handle these exceptions:

   * Resolves: https://github.com/blakeblackshear/frigate-hass-integration/issues/1