### PR TITLE
Remove listener on entry unload to avoid multiple listeners.

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -133,7 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-    entry.add_update_listener(_async_entry_updated)
+    entry.async_on_unload(entry.add_update_listener(_async_entry_updated))
     return True
 
 


### PR DESCRIPTION
   * Resolves: https://github.com/blakeblackshear/frigate-hass-integration/issues/104