### PR TITLE
Minor doc fixes to sync README and HACS info.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://img.shields.io/github/workflow/status/blakeblackshear/frigate-hass-integration/Build?style=flat-square)](https://github.com/blakeblackshear/frigate-hass-integration/actions/workflows/build.yaml)
 [![Test Coverage](https://img.shields.io/codecov/c/gh/blakeblackshear/frigate-hass-integration?style=flat-square)](https://app.codecov.io/gh/blakeblackshear/frigate-hass-integration/)
 [![License](https://img.shields.io/github/license/blakeblackshear/frigate-hass-integration.svg?style=flat-square)](LICENSE)
-[![hacs](https://img.shields.io/badge/HACS-default-orange.svg?style=flat-square)](https://hacs.xyz)
+[![hacs](https://img.shields.io/badge/HACS-custom-orange.svg?style=flat-square)](https://hacs.xyz)
 
 # Frigate Home Assistant Integration
 

--- a/info.md
+++ b/info.md
@@ -4,9 +4,11 @@ This is a custom component to integrate [Frigate](https://github.com/blakeblacks
 
 Provides the following:
 - Rich media browser with thumbnails and navigation
-- Sensor entities
-- Camera entities
-- Switch entities
+- Sensor entities (Camera FPS, Detection FPS, Process FPS, Skipped FPS, Objects detected)
+- Binary Sensor entities (Object motion)
+- Camera entities (Live view, Object detected snapshot)
+- Switch entities (Clips, Detection, Snapshots)
+- Support for multiple Frigate instances.
 
 ## Information on Frigate (Available as an Addon)
 A complete and local NVR designed for Home Assistant with AI object detection. Uses OpenCV and Tensorflow to perform realtime object detection locally for IP cameras.
@@ -18,5 +20,5 @@ Use of a [Google Coral Accelerator](https://coral.ai/products/) is optional, but
 - Uses a very low overhead motion detection to determine where to run object detection
 - Object detection with TensorFlow runs in separate processes for maximum FPS
 - Communicates over MQTT for easy integration into other systems
-- 24/7 recording
+- Optional 24/7 recording
 - Re-streaming via RTMP to reduce the number of connections to your camera


### PR DESCRIPTION
   * Sync the README features with the info.md features.
   * Change the HACS logo to custom.

@blakeblackshear I somehow thought this integration was in HACS default already (rather than custom). Being in default will  show it up in the 'store' which may help drive usage / ease installation. Any objection to me adding it there?