### PR TITLE
Changes for HA >= 2021.8.0.dev0

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -11,11 +11,12 @@ import logging
 import re
 from typing import Any, Callable, Final
 
+from awesomeversion import AwesomeVersion
+
 from custom_components.frigate.config_flow import get_config_entry_title
-from homeassistant.components.mqtt.models import Message
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL
+from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL, __version__
 from homeassistant.core import Config, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
@@ -25,6 +26,15 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify
 
+# To be removed once 2021.8 has been officially released.
+if AwesomeVersion(__version__) < AwesomeVersion("2021.8.0"):
+    from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
+        Message as ReceiveMessage,
+    )
+else:
+    from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
+        ReceiveMessage,
+    )
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
     ATTR_CLIENT,
@@ -292,12 +302,12 @@ class FrigateMQTTEntity(FrigateEntity):
         )
 
     @callback  # type: ignore[misc]
-    def _state_message_received(self, msg: Message) -> None:
+    def _state_message_received(self, msg: ReceiveMessage) -> None:
         """State message received."""
         self.async_write_ha_state()
 
     @callback  # type: ignore[misc]
-    def _availability_message_received(self, msg: Message) -> None:
+    def _availability_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT availability message."""
         self._available = msg.payload == "online"
         self.async_write_ha_state()

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -27,7 +27,7 @@ from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify
 
 # To be removed once 2021.8 has been officially released.
-if AwesomeVersion(__version__) < AwesomeVersion("2021.8.0"):
+if AwesomeVersion(__version__) < AwesomeVersion("2021.8.0.dev0"):
     from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
         Message as ReceiveMessage,
     )

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -8,13 +8,13 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
     BinarySensorEntity,
 )
-from homeassistant.components.mqtt.models import Message
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
     FrigateMQTTEntity,
+    ReceiveMessage,
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
@@ -65,7 +65,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
         )
 
     @callback  # type: ignore[misc]
-    def _state_message_received(self, msg: Message) -> None:
+    def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
         try:
             self._is_on = int(msg.payload) > 0

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -10,7 +10,6 @@ from jinja2 import Template
 from yarl import URL
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
-from homeassistant.components.mqtt.models import Message
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
@@ -21,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import (
     FrigateEntity,
     FrigateMQTTEntity,
+    ReceiveMessage,
     get_cameras_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
@@ -177,7 +177,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         Camera.__init__(self)
 
     @callback  # type: ignore[misc]
-    def _state_message_received(self, msg: Message) -> None:
+    def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
         self._last_image = msg.payload
         super()._state_message_received(msg)

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.mqtt.models import Message
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
@@ -15,6 +14,7 @@ from . import (
     FrigateDataUpdateCoordinator,
     FrigateEntity,
     FrigateMQTTEntity,
+    ReceiveMessage,
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
@@ -297,7 +297,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
         )
 
     @callback  # type: ignore[misc]
-    def _state_message_received(self, msg: Message) -> None:
+    def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
         try:
             self._state = int(msg.payload)

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 from homeassistant.components.mqtt import async_publish
-from homeassistant.components.mqtt.models import Message
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -14,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
     FrigateMQTTEntity,
+    ReceiveMessage,
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
@@ -87,7 +87,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
         )
 
     @callback  # type: ignore[misc]
-    def _state_message_received(self, msg: Message) -> None:
+    def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
         self._is_on = msg.payload == "ON"
         super()._state_message_received(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp
 aiohttp_cors==0.7.0
 attr
+awesomeversion
 homeassistant==2021.6.2
 paho-mqtt==1.5.1
 homeassistant==2021.6.2


### PR DESCRIPTION
An import path was changed on the HomeAssistant dev branch. Update our import to work both pre/post this change to ensure our versions are not coupled. After a suitable period of time post launch of  2021.8.0, this can be ~removed.