### PR TITLE
Support snapshots in the media browser

### DIFF
--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -59,6 +59,8 @@ class FrigateApiClient:
         after: int | None = None,
         before: int | None = None,
         limit: int | None = None,
+        has_clip: bool | None = None,
+        has_snapshot: bool | None = None,
     ) -> list[dict[str, Any]]:
         """Get data from the API."""
         params = {
@@ -68,7 +70,8 @@ class FrigateApiClient:
             "after": after,
             "before": before,
             "limit": limit,
-            "has_clip": 1,
+            "has_clip": int(has_clip) if has_clip is not None else None,
+            "has_snapshot": int(has_snapshot) if has_snapshot is not None else None,
         }
 
         return cast(
@@ -78,17 +81,31 @@ class FrigateApiClient:
                 str(
                     URL(self._host)
                     / "api/events"
-                    % {k: v for k, v in params.items() if v}
+                    % {k: v for k, v in params.items() if v is not None}
                 ),
             ),
         )
 
-    async def async_get_event_summary(self) -> list[dict[str, Any]]:
+    async def async_get_event_summary(
+        self,
+        has_clip: bool | None = None,
+        has_snapshot: bool | None = None,
+    ) -> list[dict[str, Any]]:
         """Get data from the API."""
+        params = {
+            "has_clip": int(has_clip) if has_clip is not None else None,
+            "has_snapshot": int(has_snapshot) if has_snapshot is not None else None,
+        }
+
         return cast(
             List[Dict[str, Any]],
             await self.api_wrapper(
-                "get", str(URL(self._host) / "api/events/summary" % {"has_clip": 1})
+                "get",
+                str(
+                    URL(self._host)
+                    / "api/events/summary"
+                    % {k: v for k, v in params.items() if v is not None}
+                ),
             ),
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,10 +102,11 @@ async def test_async_get_events(
         after=1,
         before=2,
         limit=3,
+        has_clip=True,
     )
 
 
-async def test_async_get_event_summary(
+async def test_async_get_event_summary_clips(
     aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
 ) -> None:
     """Test async_get_event_summary."""
@@ -118,10 +119,14 @@ async def test_async_get_event_summary(
             "zones": [],
         },
     ]
+    expected_params = [
+        {"has_clip": "1"},
+        {"has_snapshot": "1"},
+    ]
 
     async def events_summary_handler(request: web.Request) -> web.Response:
         """Events summary handler."""
-        _assert_request_params(request, {"has_clip": "1"})
+        _assert_request_params(request, expected_params.pop(0))
         return web.json_response(events_summary_in)
 
     server = await start_frigate_server(
@@ -129,7 +134,13 @@ async def test_async_get_event_summary(
     )
 
     frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
-    assert events_summary_in == await frigate_client.async_get_event_summary()
+
+    assert events_summary_in == await frigate_client.async_get_event_summary(
+        has_clip=True,
+    )
+    assert events_summary_in == await frigate_client.async_get_event_summary(
+        has_snapshot=True,
+    )
 
 
 async def test_async_get_config(


### PR DESCRIPTION
   * Add snapshot  support for the media browser by introducing a new FrigateMediaType enum, and adding it to the  existing  identifier.
   * Take the opportunity to be more meticulous in choice of media class/type.
   * Update necessary test coverage.
   * Closes #112 

<img width="559" alt="Screen Shot 2021-07-28 at 8 11 25 PM" src="https://user-images.githubusercontent.com/1136829/127432575-198c1eca-5aa8-42f7-bad6-ee336b1c28b8.png">
