### PR TITLE
Bump version to v1.1.0 

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -2,7 +2,7 @@
     "domain": "frigate",
     "documentation": "https://github.com/blakeblackshear/frigate",
     "name": "Frigate",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "dependencies": [
         "http",


### PR DESCRIPTION
Bump version to v1.1.0 .
   * Increment the minor number (1.0.6 -> 1.1.0) to indicate this is a significant change in functionality since the last release, although in a backwards compatible way.
   * In particular https://github.com/blakeblackshear/frigate-hass-integration/pull/92 is a significant underlying change to how the integration represents itself on disk.