### PR TITLE
Fix broken import experienced by users of certain versions of HomeAssistant

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -11,12 +11,10 @@ import logging
 import re
 from typing import Any, Callable, Final
 
-from awesomeversion import AwesomeVersion
-
 from custom_components.frigate.config_flow import get_config_entry_title
 from homeassistant.components.mqtt.subscription import async_subscribe_topics
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL, __version__
+from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL
 from homeassistant.core import Config, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
@@ -26,14 +24,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify
 
-# To be removed once 2021.8 has been officially released.
-if AwesomeVersion(__version__) < AwesomeVersion("2021.8.0.dev0"):
-    from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
-        Message as ReceiveMessage,
-    )
-else:
+# TODO(@dermotduffy): To be removed some safe distance from the official release of 2021.8.
+try:
     from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
         ReceiveMessage,
+    )
+except ImportError:
+    from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
+        Message as ReceiveMessage,
     )
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 aiohttp
 aiohttp_cors==0.7.0
 attr
-awesomeversion
 homeassistant==2021.6.2
 paho-mqtt==1.5.1
 homeassistant==2021.6.2


### PR DESCRIPTION
   * Rather than trying to precisely identify the set of versions that are before/after the type change, just try to import both -- starting with the new one, and falling back to the old one.
   * Verified working on the Home Assistant `2021.8.0b5` (which was failing before)
   * Closes #119