### PR TITLE
Bump version to v1.1.1

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -2,7 +2,7 @@
     "domain": "frigate",
     "documentation": "https://github.com/blakeblackshear/frigate",
     "name": "Frigate",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "dependencies": [
         "http",


### PR DESCRIPTION
   * Bump the version number (and then do a new pre-release) to pull in https://github.com/blakeblackshear/frigate-hass-integration/pull/120 , as otherwise the new version will not work for a segment of the intended audience.