### PR TITLE
Unsubscribe from mqtt topic on unload to resolve log spam on entity disable

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -12,7 +12,10 @@ import re
 from typing import Any, Callable, Final
 
 from custom_components.frigate.config_flow import get_config_entry_title
-from homeassistant.components.mqtt.subscription import async_subscribe_topics
+from homeassistant.components.mqtt.subscription import (
+    async_subscribe_topics,
+    async_unsubscribe_topics,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL
 from homeassistant.core import Config, HomeAssistant, callback
@@ -298,6 +301,11 @@ class FrigateMQTTEntity(FrigateEntity):
                 },
             },
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cleanup prior to hass removal."""
+        await async_unsubscribe_topics(self.hass, self._sub_state)
+        self._sub_state = None
 
     @callback  # type: ignore[misc]
     def _state_message_received(self, msg: ReceiveMessage) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import async_fire_mqtt_message
@@ -124,3 +124,15 @@ async def test_binary_sensor_unique_id(hass: HomeAssistant) -> None:
         registry_entry.unique_id
         == f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"
     )
+
+
+async def test_binary_sensor_unload_will_unsubscribe(hass: HomeAssistant) -> None:
+    """Verify entity unique_id(s)."""
+    mock_unsubscribe = AsyncMock()
+    with patch(
+        "custom_components.frigate.async_unsubscribe_topics", new=mock_unsubscribe
+    ):
+        config_entry = await setup_mock_frigate_config_entry(hass)
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+        mock_unsubscribe.assert_called()


### PR DESCRIPTION
   * We were not unsubscribing from the mqtt topic, which meant mqtt updates were triggering state updates, causing an appropriate log message:

```
Entity binary_sensor.zone_garage_on_property_bicycle_motion is incorrectly being triggered for updates while it is disabled. This is a bug in the frigate integration
```

Closes #128 