### PR TITLE
Bump version to v2.0.0 .

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -2,7 +2,7 @@
     "domain": "frigate",
     "documentation": "https://github.com/blakeblackshear/frigate",
     "name": "Frigate",
-    "version": "1.1.2",
+    "version": "2.0.0",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "dependencies": [
         "http",


### PR DESCRIPTION
Bumping to v2.0.0 since this is a backwards incompatible change in accordance with semantic versioning.