### PR TITLE
Retire 'camera_image_height' option.

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -35,7 +35,7 @@ try:
     from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
         ReceiveMessage,
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     from homeassistant.components.mqtt.models import (  # pylint: disable=no-name-in-module  # pragma: no cover
         Message as ReceiveMessage,
     )
@@ -45,6 +45,7 @@ from .const import (
     ATTR_CLIENT,
     ATTR_CONFIG,
     ATTR_COORDINATOR,
+    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     DOMAIN,
     FRIGATE_RELEASES_URL,
     FRIGATE_VERSION_ERROR_CUTOFF,
@@ -166,9 +167,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ATTR_MODEL: model,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
-    entry.async_on_unload(entry.add_update_listener(_async_entry_updated))
-
     # Cleanup old clips switch (<v0.9.0) if it exists.
     entity_registry = er.async_get(hass)
     for camera in config["cameras"].keys():
@@ -180,6 +178,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         if entity_id:
             entity_registry.async_remove(entity_id)
+
+    # Remove old `camera_image_height` option.
+    if CONF_CAMERA_STATIC_IMAGE_HEIGHT in entry.options:
+        new_options = entry.options.copy()
+        new_options.pop(CONF_CAMERA_STATIC_IMAGE_HEIGHT)
+        hass.config_entries.async_update_entry(entry, options=new_options)
+
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_entry_updated))
 
     return True
 

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -28,9 +28,7 @@ from . import (
 )
 from .const import (
     ATTR_CONFIG,
-    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_RTMP_URL_TEMPLATE,
-    DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT,
     DOMAIN,
     NAME,
     STATE_DETECTED,
@@ -122,18 +120,16 @@ class FrigateCamera(FrigateEntity, Camera):  # type: ignore[misc]
             return 0
         return cast(int, SUPPORT_STREAM)
 
-    async def async_camera_image(self) -> bytes:
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
         """Return bytes of camera image."""
         websession = cast(aiohttp.ClientSession, async_get_clientsession(self.hass))
-
-        height = self._config_entry.options.get(
-            CONF_CAMERA_STATIC_IMAGE_HEIGHT, DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT
-        )
 
         image_url = str(
             URL(self._url)
             / f"api/{self._cam_name}/latest.jpg"
-            % ({"h": height} if height > 0 else {})
+            % ({"h": height} if height is not None and height > 0 else {})
         )
 
         with async_timeout.timeout(10):

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -15,10 +15,8 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
-    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_RTMP_URL_TEMPLATE,
-    DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT,
     DEFAULT_HOST,
     DOMAIN,
 )
@@ -126,38 +124,30 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                 Dict[str, Any], self.async_create_entry(title="", data=user_input)
             )
 
-        schema: dict[Any, Any] = {
-            vol.Optional(
-                CONF_CAMERA_STATIC_IMAGE_HEIGHT,
-                default=self._config_entry.options.get(
-                    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
-                    DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT,
-                ),
-            ): vol.All(vol.Coerce(int), vol.Range(min=0)),
-        }
-
-        if self.show_advanced_options:
-            schema.update(
-                {
-                    # The input URL is not validated as being a URL to allow for the
-                    # possibility the template input won't be a valid URL until after
-                    # it's rendered.
-                    vol.Optional(
-                        CONF_RTMP_URL_TEMPLATE,
-                        default=self._config_entry.options.get(
-                            CONF_RTMP_URL_TEMPLATE,
-                            "",
-                        ),
-                    ): str,
-                    vol.Optional(
-                        CONF_NOTIFICATION_PROXY_ENABLE,
-                        default=self._config_entry.options.get(
-                            CONF_NOTIFICATION_PROXY_ENABLE,
-                            True,
-                        ),
-                    ): bool,
-                }
+        if not self.show_advanced_options:
+            return cast(
+                Dict[str, Any], self.async_abort(reason="only_advanced_options")
             )
+
+        schema: dict[Any, Any] = {
+            # The input URL is not validated as being a URL to allow for the
+            # possibility the template input won't be a valid URL until after
+            # it's rendered.
+            vol.Optional(
+                CONF_RTMP_URL_TEMPLATE,
+                default=self._config_entry.options.get(
+                    CONF_RTMP_URL_TEMPLATE,
+                    "",
+                ),
+            ): str,
+            vol.Optional(
+                CONF_NOTIFICATION_PROXY_ENABLE,
+                default=self._config_entry.options.get(
+                    CONF_NOTIFICATION_PROXY_ENABLE,
+                    True,
+                ),
+            ): bool,
+        }
 
         return cast(
             Dict[str, Any],

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -40,7 +40,6 @@ CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
 
 # Defaults
-DEFAULT_CAMERA_STATIC_IMAGE_HEIGHT = 277
 DEFAULT_NAME = DOMAIN
 DEFAULT_HOST = "http://ccab4aaf-frigate:5000"
 

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -22,10 +22,12 @@
             "init": {
                 "data": {
                     "rtmp_url_template": "RTMP URL template (see documentation)",
-                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
-                    "camera_image_height": "Height of live camera static images. 0 for camera default."
+                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy"
                 }
             }
+        },
+        "abort": {
+            "only_advanced_options": "Advanced mode is disabled and there are only advanced options"
         }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 aiohttp
 aiohttp_cors==0.7.0
 attr
-homeassistant==2021.6.2
+homeassistant==2021.9.0b2
 paho-mqtt==1.5.1
-homeassistant==2021.6.2
 python-dateutil
 yarl

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ flake8
 mypy==0.910
 pre-commit
 pytest==6.2.4
-pytest-homeassistant-custom-component==0.4.1
+pytest-homeassistant-custom-component==0.4.4
 pylint-pytest
 pylint==2.8.3
 pytest-aiohttp==0.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ from pytest_homeassistant_custom_component.plugins import (  # noqa: F401
     enable_custom_integrations,
 )
 
+from homeassistant.components.http import CONF_TRUSTED_PROXIES, CONF_USE_X_FORWARDED_FOR
+from homeassistant.setup import async_setup_component
+
 pytest_plugins = "pytest_homeassistant_custom_component"  # pylint: disable=invalid-name
 
 
@@ -23,8 +26,32 @@ def skip_notifications_fixture() -> Generator:
         yield
 
 
+def pytest_configure(config: Any) -> None:
+    """Configure pytest to recognize custom markers."""
+    config.addinivalue_line("markers", "allow_proxy: Allow trusted proxy in http setup")
+
+
+@pytest.fixture(name="allow_proxy")
+async def allow_proxy(request: Any, hass: Any) -> None:
+    """Configure http to allow a proxy."""
+    if "allow_proxy" in request.keywords:
+        # Configure http component to allow proxy before any other component can
+        # depend on, and load, http.
+        await async_setup_component(
+            hass,
+            "http",
+            {
+                "http": {
+                    CONF_USE_X_FORWARDED_FOR: True,
+                    CONF_TRUSTED_PROXIES: ["127.0.0.1"],
+                }
+            },
+        )
+
+
 @pytest.fixture(autouse=True)
 def frigate_fixture(
+    allow_proxy: Any,
     skip_notifications: Any,
     enable_custom_integrations: Any,  # noqa: F811
     hass: Any,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
-    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_RTMP_URL_TEMPLATE,
     DOMAIN,
@@ -201,10 +200,6 @@ async def test_options(hass: HomeAssistant) -> None:
         result = await hass.config_entries.options.async_init(
             config_entry.entry_id,
         )
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={CONF_CAMERA_STATIC_IMAGE_HEIGHT: 1000},
-        )
-        await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["data"][CONF_CAMERA_STATIC_IMAGE_HEIGHT] == 1000
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "only_advanced_options"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate.api import FrigateApiClientError
-from custom_components.frigate.const import DOMAIN
+from custom_components.frigate.const import CONF_CAMERA_STATIC_IMAGE_HEIGHT, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant
@@ -18,6 +18,7 @@ from homeassistant.loader import async_get_integration
 from . import (
     TEST_CONFIG_ENTRY_ID,
     create_mock_frigate_client,
+    create_mock_frigate_config_entry,
     setup_mock_frigate_config_entry,
 )
 
@@ -240,3 +241,18 @@ async def test_startup_message(caplog: Any, hass: HomeAssistant) -> None:
     integration = await async_get_integration(hass, DOMAIN)
     assert integration.version in caplog.text
     assert "This is a custom integration" in caplog.text
+
+
+async def test_entry_remove_old_image_height_option(hass: HomeAssistant) -> None:
+    """Test cleanup of old image height option."""
+
+    config_entry = create_mock_frigate_config_entry(
+        hass, options={CONF_CAMERA_STATIC_IMAGE_HEIGHT: 42}
+    )
+
+    await setup_mock_frigate_config_entry(hass, config_entry)
+
+    assert (
+        CONF_CAMERA_STATIC_IMAGE_HEIGHT
+        not in hass.config_entries.async_get_entry(config_entry.entry_id).options
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -30,7 +30,6 @@ from homeassistant.const import (
     HTTP_UNAUTHORIZED,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from . import (
     TEST_CONFIG,
@@ -98,7 +97,6 @@ async def hass_client_local_frigate(
     hass: HomeAssistant, hass_client: Any, aiohttp_server: Any
 ) -> Any:
     """Point the integration at a local fake Frigate server."""
-    await async_setup_component(hass, "http", {"http": {}})
 
     async def handler(request: web.Request) -> web.Response:
         for header in (
@@ -310,11 +308,12 @@ async def test_notifications_proxy_other(
     assert resp.status == HTTP_NOT_FOUND
 
 
+@pytest.mark.allow_proxy
 async def test_headers(
+    hass: Any,
     hass_client_local_frigate: Any,
 ) -> None:
-    """Test notification clip."""
-
+    """Test proxy headers are added and respected."""
     resp = await hass_client_local_frigate.get(
         "/api/frigate/notifications/event_id/thumbnail.jpg",
         headers={hdrs.CONTENT_ENCODING: "foo"},
@@ -323,7 +322,7 @@ async def test_headers(
 
     resp = await hass_client_local_frigate.get(
         "/api/frigate/notifications/event_id/thumbnail.jpg",
-        headers={hdrs.X_FORWARDED_FOR: "forwarded_for"},
+        headers={hdrs.X_FORWARDED_FOR: "1.2.3.4"},
     )
     assert resp.status == HTTP_OK
 


### PR DESCRIPTION
* Leverage the new Home Assistant functionality to accept width/height parameters for image fetching.
* Retire the 'camera_image_height' option -- it will be automatically removed from Frigate config entries.
* Closes #138 

Breaking behavior:

* Previously, the 'camera_image_height' configuration option would dictate the height of all images captured from the camera (i.e. both lovelace, and `camera.snapshot` service).
* With this PR, by default, the maximum size will be returned unless specifically requested otherwise. Right now, the width/height choices are not yet externalized to the `camera.snapshot` service, so callers will only have the choice of 'full size'.

So why make this  change:

* The motivation for the option in the first place was to reduce the bandwidth / increase the speed of Lovelace dashboards loading from the camera. Lovelace *does* pass  width/height parameters (observed behavior: Lovelace requests images  of height <=  554, which is 2x the default value the integration currently has @ 277, so this does increase the bandwidth required, but still considerably lower than full size images). Lovelace also can/does request smaller images in some circumstances.
* The vast majority of users will assume/expect max image size when they call `camera.snapshot` (i.e. the change in behavior is arguably a return to expected).
* The option as-is is subjectively 'odd-ball', equivalent to a global variable for camera images. Code is simpler without it.

Unrelated:
* The change required the upgrade of the underlying `homeassistant` library. This change introduced some reverse proxy protections, and unittests needed some tweaks to continue to work with those protections.