### PR TITLE
 Adapt to changed mqtt.async_publish in HA core 2021.12

### DIFF
--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -126,7 +126,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        async_publish(
+        await async_publish(
             self.hass,
             self._command_topic,
             "ON",
@@ -136,7 +136,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        async_publish(
+        await async_publish(
             self.hass,
             self._command_topic,
             "OFF",

--- a/hacs.json
+++ b/hacs.json
@@ -9,5 +9,5 @@
         "switch"
     ],
     "iot_class": "Local Push",
-    "homeassistant": "2021.12.0"
+    "homeassistant": "2021.12.0b0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -9,5 +9,5 @@
         "switch"
     ],
     "iot_class": "Local Push",
-    "homeassistant": "0.115.0"
+    "homeassistant": "2021.12.0"
 }


### PR DESCRIPTION
mqtt.async_publish is a couroutine in HA core 2021.12: https://github.com/home-assistant/core/pull/58441

This PR bumps the minimum version of HA to 2021.12.0.

If this is not wanted, something like this would work to keep compatibility with old versions of Home Assistant Core:
```py
hass.async_add_job(async_publish, hass, topic, payload)
```