### PR TITLE
Allow setting an expiration time for unauthenticated notification events

### DIFF
--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Dict, cast
 
 import voluptuous as vol
+from voluptuous.validators import All, Range
 from yarl import URL
 
 from homeassistant import config_entries
@@ -16,6 +17,7 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
     CONF_NOTIFICATION_PROXY_ENABLE,
+    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
     CONF_RTMP_URL_TEMPLATE,
     DEFAULT_HOST,
     DOMAIN,
@@ -147,6 +149,13 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                     True,
                 ),
             ): bool,
+            vol.Optional(
+                CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+                default=self._config_entry.options.get(
+                    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+                    0,
+                ),
+            ): All(int, Range(min=0)),
         }
 
         return cast(

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -38,6 +38,7 @@ ATTR_CLIENT_ID = "client_id"
 CONF_CAMERA_STATIC_IMAGE_HEIGHT = "camera_image_height"
 CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
+CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS = "expire_notifications_after_mins"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -22,7 +22,8 @@
             "init": {
                 "data": {
                     "rtmp_url_template": "RTMP URL template (see documentation)",
-                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy"
+                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
+                    "expire_notifications_after_mins": "Expire notifications after minutes (0=never)"
                 }
             }
         },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,6 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
+    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_RTMP_URL_TEMPLATE,
     DOMAIN,
@@ -174,11 +175,13 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
             user_input={
                 CONF_RTMP_URL_TEMPLATE: "http://moo",
                 CONF_NOTIFICATION_PROXY_ENABLE: False,
+                CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS: 50
             },
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_RTMP_URL_TEMPLATE] == "http://moo"
+        assert result["data"][CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS] == 50
         assert not result["data"][CONF_NOTIFICATION_PROXY_ENABLE]
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from datetime import timedelta
+from datetime import datetime, timedelta
 from http import HTTPStatus
 import logging
 from typing import Any
@@ -18,6 +18,7 @@ from custom_components.frigate import views
 from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_MQTT,
+    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
     DOMAIN,
 )
@@ -149,6 +150,9 @@ async def hass_client_local_frigate(
             web.get("/api/events/event_id/thumbnail.jpg", handler),
             web.get("/api/events/event_id/snapshot.jpg", handler),
             web.get("/api/events/event_id/clip.mp4", handler),
+            web.get("/api/events/1577854800.123456-random/snapshot.jpg", handler),
+            web.get("/api/events/1635807600.123456-random/snapshot.jpg", handler),
+            web.get("/api/events/1635807359.123456-random/snapshot.jpg", handler),
             web.get("/live/front_door", ws_echo_handler),
             web.get("/live/querystring", ws_qs_echo_handler),
         ],
@@ -518,6 +522,95 @@ async def test_notifications_with_disabled_option(
         "/api/frigate/private_id/notifications/event_id/snapshot.jpg"
     )
     assert resp.status == HTTPStatus.FORBIDDEN
+
+async def test_notifications_with_no_expiration(
+    hass_client_local_frigate: Any,
+    hass: Any,
+) -> None:
+    """Test that notification events are served if they are set to not expire."""
+
+    # Make another config entry with the same data but with
+    # CONF_NOTIFICATION_PROXY_ENABLE disabled.
+    private_config_entry = create_mock_frigate_config_entry(
+        hass,
+        entry_id="private_id",
+        options={CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS: 0},
+        data=hass.config_entries.async_get_entry(TEST_CONFIG_ENTRY_ID).data,
+    )
+
+    private_config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
+    private_config[ATTR_MQTT][ATTR_CLIENT_ID] = "private_id"
+    private_client = create_mock_frigate_client()
+    private_client.async_get_config = AsyncMock(return_value=private_config)
+
+    await setup_mock_frigate_config_entry(
+        hass, config_entry=private_config_entry, client=private_client
+    )
+
+    # Fake time is 2021-11-01T19:02:00
+    with patch("custom_components.frigate.views.NotificationsProxyView._get_current_datetime",
+    return_value=datetime(2021, 11, 1, 19, 2, 00, 000000)):
+
+        # Old event id should be vended
+        # Test event timestamp is 2020-01-01 00:00:00
+        resp = await hass_client_local_frigate.get(
+            f"/api/frigate/private_id/notifications/1577854800.123456-random/snapshot.jpg"
+        )
+        assert resp.status == HTTPStatus.OK
+
+async def test_get_current_datetime() -> None:
+    """Test datetime helper."""
+    datetime_1 = views.NotificationsProxyView._get_current_datetime()
+    datetime_2 = views.NotificationsProxyView._get_current_datetime()
+    assert isinstance(datetime_1, datetime)
+    assert isinstance(datetime_2, datetime)
+    assert datetime_1 <= datetime_2
+
+async def test_expired_notifications_are_not_served(
+    hass_client_local_frigate: Any,
+    hass: Any,
+) -> None:
+    """Test that notification events are not served if older than expiration config."""
+    private_config_entry = create_mock_frigate_config_entry(
+        hass,
+        entry_id="private_id",
+        # for this test, notifications expire after 5 minutes from the event
+        options={CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS: 5},
+        data=hass.config_entries.async_get_entry(TEST_CONFIG_ENTRY_ID).data,
+    )
+
+    private_config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
+    private_config[ATTR_MQTT][ATTR_CLIENT_ID] = "private_id"
+    private_client = create_mock_frigate_client()
+    private_client.async_get_config = AsyncMock(return_value=private_config)
+
+    await setup_mock_frigate_config_entry(
+        hass, config_entry=private_config_entry, client=private_client
+    )
+
+    # Fake time is 2021-11-01T19:02:00
+    with patch("custom_components.frigate.views.NotificationsProxyView._get_current_datetime",
+    return_value=datetime(2021, 11, 1, 19, 2, 00, 000000)):
+
+        # Well-formed, not expired events should be vended
+        # Test event timestamp is 2021-11-01T19:00:00 - 2 minutes prior test (fake) time
+        resp = await hass_client_local_frigate.get(
+            f"/api/frigate/private_id/notifications/1635807600.123456-random/snapshot.jpg"
+        )
+        assert resp.status == HTTPStatus.OK
+
+        # Expired event ids should not be vended
+        # Test event timestamp is 2021-11-01T18:55:59 - 6:01 minutes prior test (fake) time
+        resp = await hass_client_local_frigate.get(
+            f"/api/frigate/private_id/notifications/1635807359.123456-random/snapshot.jpg"
+        )
+        assert resp.status == HTTPStatus.FORBIDDEN
+
+        # Invalid event ids should not be vended
+        resp = await hass_client_local_frigate.get(
+            f"/api/frigate/private_id/notifications/invalid.123456-random/snapshot.jpg"
+        )
+        assert resp.status == HTTPStatus.FORBIDDEN
 
 
 async def test_jsmpeg_text_binary(


### PR DESCRIPTION
Resolves #153 

The unauthenticated notifications proxy gives access to event data in
perpetuity. If a URL is shared or leaks, it is valid for the lifetime of
the event id.

This change allows the user to set an expiration time (in minutes) for
the notification event to be valid. After this time, the notification
proxy will not allow the event to be accessed, and the user will have to
go through the typical Frigate flow to retrieve snapshots/clips etc.

If the user sets the expiration time to 0 (default) this feature is
disabled.