### PR TITLE
Allow setting an expiration time for unauthenticated notification events

### DIFF
--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -18,7 +18,7 @@ from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
-    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     CONF_RTMP_URL_TEMPLATE,
     DEFAULT_HOST,
     DOMAIN,
@@ -158,9 +158,9 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                 ),
             ): bool,
             vol.Optional(
-                CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
+                CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
                 default=self._config_entry.options.get(
-                    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
+                    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
                     0,
                 ),
             ): All(int, Range(min=0)),

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -18,7 +18,7 @@ from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
-    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
     CONF_RTMP_URL_TEMPLATE,
     DEFAULT_HOST,
     DOMAIN,
@@ -158,9 +158,9 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                 ),
             ): bool,
             vol.Optional(
-                CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+                CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
                 default=self._config_entry.options.get(
-                    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+                    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
                     0,
                 ),
             ): All(int, Range(min=0)),

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, Dict, cast
 
 import voluptuous as vol
+from voluptuous.validators import All, Range
 from yarl import URL
 
 from homeassistant import config_entries
@@ -17,6 +18,7 @@ from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
+    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
     CONF_RTMP_URL_TEMPLATE,
     DEFAULT_HOST,
     DOMAIN,
@@ -155,6 +157,13 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[mis
                     True,
                 ),
             ): bool,
+            vol.Optional(
+                CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+                default=self._config_entry.options.get(
+                    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+                    0,
+                ),
+            ): All(int, Range(min=0)),
         }
 
         return cast(

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -55,6 +55,7 @@ CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_PASSWORD = "password"
 CONF_PATH = "path"
 CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
+CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS = "expire_notifications_after_mins"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -55,7 +55,7 @@ CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_PASSWORD = "password"
 CONF_PATH = "path"
 CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
-CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS = "notification_proxy_expire_after_mins"
+CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS = "notification_proxy_expire_after_seconds"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -55,7 +55,7 @@ CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_PASSWORD = "password"
 CONF_PATH = "path"
 CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
-CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS = "expire_notifications_after_mins"
+CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS = "notification_proxy_expire_after_mins"
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -21,9 +21,9 @@
             "init": {
                 "data": {
                     "rtmp_url_template": "RTMP URL template (see documentation)",
-                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
                     "media_browser_enable": "Enable the media browser",
-                    "notification_proxy_expire_after_mins": "Expire notifications after minutes (0=never)"
+                    "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
+                    "notification_proxy_expire_after_seconds": "Disallow unauthenticated notification access after seconds (0=never)"
                 }
             }
         },

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -23,7 +23,7 @@
                     "rtmp_url_template": "RTMP URL template (see documentation)",
                     "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
                     "media_browser_enable": "Enable the media browser",
-                    "expire_notifications_after_mins": "Expire notifications after minutes (0=never)"
+                    "notification_proxy_expire_after_mins": "Expire notifications after minutes (0=never)"
                 }
             }
         },

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -22,7 +22,8 @@
                 "data": {
                     "rtmp_url_template": "RTMP URL template (see documentation)",
                     "notification_proxy_enable": "Enable the unauthenticated notification event proxy",
-                    "media_browser_enable": "Enable the media browser"
+                    "media_browser_enable": "Enable the media browser",
+                    "expire_notifications_after_mins": "Expire notifications after minutes (0=never)"
                 }
             }
         },

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 from collections.abc import Mapping
+import datetime
 from http import HTTPStatus
 from ipaddress import ip_address
 import logging
@@ -22,11 +22,11 @@ from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_CONFIG,
     ATTR_MQTT,
-    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
     DOMAIN,
 )
-from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
 from homeassistant.components.http.auth import DATA_SIGN_SECRET, SIGN_QUERY_PARAM
 from homeassistant.components.http.const import KEY_HASS
 from homeassistant.config_entries import ConfigEntry
@@ -258,12 +258,16 @@ class NotificationsProxyView(ProxyView):
         if not is_notification_proxy_enabled:
             return False
 
-        # If request is not authenticated, check whether it is expired
+        # Authenticated requests are always allowed.
+        if request[KEY_AUTHENTICATED]:
+            return True
+
+        # If request is not authenticated, check whether it is expired.
         notification_expiration_mins = int(
             config_entry.options.get(CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS, 0)
         )
 
-        # If notification events never expire, immediately permit
+        # If notification events never expire, immediately permit.
         if notification_expiration_mins == 0:
             return True
 

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -23,7 +23,7 @@ from custom_components.frigate.const import (
     ATTR_CONFIG,
     ATTR_MQTT,
     CONF_NOTIFICATION_PROXY_ENABLE,
-    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     DOMAIN,
 )
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
@@ -263,12 +263,12 @@ class NotificationsProxyView(ProxyView):
             return True
 
         # If request is not authenticated, check whether it is expired.
-        notification_expiration_mins = int(
-            config_entry.options.get(CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS, 0)
+        notification_expiration_seconds = int(
+            config_entry.options.get(CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS, 0)
         )
 
         # If notification events never expire, immediately permit.
-        if notification_expiration_mins == 0:
+        if notification_expiration_seconds == 0:
             return True
 
         try:
@@ -278,7 +278,7 @@ class NotificationsProxyView(ProxyView):
             )
             now_datetime = datetime.datetime.now(tz=datetime.timezone.utc)
             expiration_datetime = event_datetime + datetime.timedelta(
-                minutes=notification_expiration_mins
+                seconds=notification_expiration_seconds
             )
 
             # Otherwise, permit only if notification event is not expired

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 from collections.abc import Mapping
 from http import HTTPStatus
 from ipaddress import ip_address
@@ -21,6 +22,7 @@ from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_CONFIG,
     ATTR_MQTT,
+    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
     DOMAIN,
 )
@@ -121,7 +123,7 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
         """Create path."""
         raise NotImplementedError  # pragma: no cover
 
-    def _permit_request(self, request: web.Request, config_entry: ConfigEntry) -> bool:
+    def _permit_request(self, request: web.Request, config_entry: ConfigEntry, **kwargs: Any) -> bool:
         """Determine whether to permit a request."""
         return True
 
@@ -155,7 +157,7 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
         if not config_entry:
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 
-        if not self._permit_request(request, config_entry):
+        if not self._permit_request(request, config_entry, **kwargs):
             return web.Response(status=HTTPStatus.FORBIDDEN)
 
         full_path = self._create_path(**kwargs)
@@ -241,9 +243,36 @@ class NotificationsProxyView(ProxyView):
             return f"api/events/{event_id}/clip.mp4"
         return None
 
-    def _permit_request(self, request: web.Request, config_entry: ConfigEntry) -> bool:
+    def _permit_request(self, request: web.Request, config_entry: ConfigEntry, **kwargs: Any) -> bool:
         """Determine whether to permit a request."""
-        return bool(config_entry.options.get(CONF_NOTIFICATION_PROXY_ENABLE, True))
+
+        is_notification_proxy_enabled = bool(config_entry.options.get(CONF_NOTIFICATION_PROXY_ENABLE, True))
+
+        # If proxy is disabled, immediately reject
+        if not is_notification_proxy_enabled:
+            return False
+
+        notification_expiration_mins = int(config_entry.options.get(CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS, 0))
+
+        # If notification events never expire, immediately permit
+        if notification_expiration_mins == 0:
+            return True
+
+        try:
+            event_id_timestamp = int(kwargs["event_id"].partition(".")[0])
+            event_datetime = datetime.datetime.fromtimestamp(event_id_timestamp)
+            expiration_datetime = NotificationsProxyView._get_current_datetime() - datetime.timedelta(minutes=notification_expiration_mins)
+
+            # Otherwise, permit only if notification event is not expired
+            return event_datetime >= expiration_datetime
+        except ValueError:
+            _LOGGER.warning("The event id %s does not have a valid format.", kwargs["event_id"])
+            return False
+
+    @staticmethod
+    def _get_current_datetime() -> datetime.datetime:
+        return datetime.datetime.now()
+
 
 
 class VodProxyView(ProxyView):
@@ -350,7 +379,7 @@ class WebsocketProxyView(ProxyView):
         if not config_entry:
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 
-        if not self._permit_request(request, config_entry):
+        if not self._permit_request(request, config_entry, **kwargs):
             return web.Response(status=HTTPStatus.FORBIDDEN)
 
         full_path = self._create_path(**kwargs)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
     CONF_MEDIA_BROWSER_ENABLE,
+    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_RTMP_URL_TEMPLATE,
     DOMAIN,
@@ -175,12 +176,14 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
             user_input={
                 CONF_RTMP_URL_TEMPLATE: "http://moo",
                 CONF_NOTIFICATION_PROXY_ENABLE: False,
+                CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS: 50
                 CONF_MEDIA_BROWSER_ENABLE: False,
             },
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_RTMP_URL_TEMPLATE] == "http://moo"
+        assert result["data"][CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS] == 50
         assert not result["data"][CONF_NOTIFICATION_PROXY_ENABLE]
         assert not result["data"][CONF_MEDIA_BROWSER_ENABLE]
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,7 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
     CONF_MEDIA_BROWSER_ENABLE,
-    CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_RTMP_URL_TEMPLATE,
     DOMAIN,
@@ -176,14 +176,14 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
             user_input={
                 CONF_RTMP_URL_TEMPLATE: "http://moo",
                 CONF_NOTIFICATION_PROXY_ENABLE: False,
-                CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS: 50
+                CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS: 50,
                 CONF_MEDIA_BROWSER_ENABLE: False,
             },
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_RTMP_URL_TEMPLATE] == "http://moo"
-        assert result["data"][CONF_EXPIRE_NOTIFICATIONS_AFTER_MINS] == 50
+        assert result["data"][CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS] == 50
         assert not result["data"][CONF_NOTIFICATION_PROXY_ENABLE]
         assert not result["data"][CONF_MEDIA_BROWSER_ENABLE]
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,8 +9,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
     CONF_MEDIA_BROWSER_ENABLE,
-    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
     CONF_NOTIFICATION_PROXY_ENABLE,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     CONF_RTMP_URL_TEMPLATE,
     DOMAIN,
 )
@@ -176,14 +176,14 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
             user_input={
                 CONF_RTMP_URL_TEMPLATE: "http://moo",
                 CONF_NOTIFICATION_PROXY_ENABLE: False,
-                CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS: 50,
+                CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS: 60,
                 CONF_MEDIA_BROWSER_ENABLE: False,
             },
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_RTMP_URL_TEMPLATE] == "http://moo"
-        assert result["data"][CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS] == 50
+        assert result["data"][CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS] == 60
         assert not result["data"][CONF_NOTIFICATION_PROXY_ENABLE]
         assert not result["data"][CONF_MEDIA_BROWSER_ENABLE]
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -19,7 +19,7 @@ from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_MQTT,
     CONF_NOTIFICATION_PROXY_ENABLE,
-    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS,
+    CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     DOMAIN,
 )
 from homeassistant.components.http.auth import async_setup_auth, async_sign_path
@@ -613,7 +613,7 @@ async def test_notifications_with_no_expiration(
     config_entry = create_mock_frigate_config_entry(
         hass,
         entry_id="private_id",
-        options={CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS: 0},
+        options={CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS: 0},
         data=hass.config_entries.async_get_entry(TEST_CONFIG_ENTRY_ID).data,
     )
 
@@ -648,7 +648,7 @@ async def test_expired_notifications_are_forbidden(
         hass,
         entry_id="private_id",
         # for this test, notifications expire after 5 minutes from the event
-        options={CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS: 5},
+        options={CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS: 5 * 60},
         data=hass.config_entries.async_get_entry(TEST_CONFIG_ENTRY_ID).data,
     )
 
@@ -696,7 +696,7 @@ async def test_expired_notifications_are_served_when_authenticated(
         hass,
         entry_id="private_id",
         # for this test, notifications expire after 5 minutes from the event
-        options={CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_MINS: 5},
+        options={CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS: 5 * 60},
         data=hass.config_entries.async_get_entry(TEST_CONFIG_ENTRY_ID).data,
     )
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -50,7 +50,7 @@ def _get_fixed_datetime() -> datetime:
     return datetime_today
 
 
-TODAY = _get_fixed_datetime()
+FIXED_TEST_DATETIME = _get_fixed_datetime()
 
 
 class ClientErrorStreamResponse(web.StreamResponse):
@@ -629,7 +629,9 @@ async def test_notifications_with_no_expiration(
     unauthenticated_hass_client = await hass_client_no_auth()
 
     # Fake time is 2021-11-01T19:02:00
-    with patch("custom_components.frigate.views.datetime.datetime", new=TODAY):
+    with patch(
+        "custom_components.frigate.views.datetime.datetime", new=FIXED_TEST_DATETIME
+    ):
         # Old event id should be served
         # Test event timestamp is 2020-01-01 00:00:00
         resp = await unauthenticated_hass_client.get(
@@ -664,7 +666,9 @@ async def test_expired_notifications_are_forbidden(
     unauthenticated_hass_client = await hass_client_no_auth()
 
     # Fake time is 2021-11-01T19:02:00
-    with patch("custom_components.frigate.views.datetime.datetime", new=TODAY):
+    with patch(
+        "custom_components.frigate.views.datetime.datetime", new=FIXED_TEST_DATETIME
+    ):
         # Well-formed, not expired events should be served
         # Test event timestamp is 2021-11-01T19:00:00 - 2 minutes prior test (fake) time
         resp = await unauthenticated_hass_client.get(
@@ -712,7 +716,9 @@ async def test_expired_notifications_are_served_when_authenticated(
     authenticated_hass_client = await hass_client()
 
     # Fake time is 2021-11-01T19:02:00
-    with patch("custom_components.frigate.views.datetime.datetime", new=TODAY):
+    with patch(
+        "custom_components.frigate.views.datetime.datetime", new=FIXED_TEST_DATETIME
+    ):
         # Expired event ids SHOULD be served since the request is authenticated.
         # Test event timestamp is 2021-11-01T18:55:59 - 6:01 minutes prior test (fake) time
         resp = await authenticated_hass_client.get(


### PR DESCRIPTION
Resolves #153 

The unauthenticated notifications proxy gives access to event data in
perpetuity. If a URL is shared or leaks, it is valid for the lifetime of
the event id.

This change allows the user to set an expiration time (in minutes) for
the notification event to be valid. After this time, the notification
proxy will not allow the event to be accessed, and the user will have to
go through the typical Frigate flow to retrieve snapshots/clips etc.

If the user sets the expiration time to 0 (default) this feature is
disabled.