### PR TITLE
Fixes to support in-progress events (Frigate 0.10+)

### DIFF
--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -88,8 +88,8 @@ class Identifier:
         """Get the identifier type."""
         raise NotImplementedError
 
-    def get_frigate_server_path(self) -> str:
-        """Get the equivalent Frigate server path."""
+    def get_integration_proxy_path(self) -> str:
+        """Get the proxy (Home Assistant view) path for this identifier."""
         raise NotImplementedError
 
     @classmethod
@@ -214,12 +214,12 @@ class EventIdentifier(Identifier):
         """Get the identifier type."""
         return "event"
 
-    def get_frigate_server_path(self) -> str:
+    def get_integration_proxy_path(self) -> str:
         """Get the equivalent Frigate server path."""
         if self.frigate_media_type == FrigateMediaType.CLIPS:
             return f"vod/event/{self.id}/index.{self.frigate_media_type.extension}"
         else:
-            return f"clips/{self.camera}-{self.id}.{self.frigate_media_type.extension}"
+            return f"snapshot/{self.id}"
 
     @property
     def mime_type(self) -> str:
@@ -433,8 +433,8 @@ class RecordingIdentifier(Identifier):
         """Get the identifier type."""
         return "recordings"
 
-    def get_frigate_server_path(self) -> str:
-        """Get the equivalent Frigate server path."""
+    def get_integration_proxy_path(self) -> str:
+        """Get the integration path that will proxy this identifier."""
 
         # The attributes of this class represent a path that the recording can
         # be retrieved from the Frigate server. If there are holes in the path
@@ -545,7 +545,7 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
             default_frigate_instance_id=self._get_default_frigate_instance_id(),
         )
         if identifier:
-            server_path = identifier.get_frigate_server_path()
+            server_path = identifier.get_integration_proxy_path()
             return PlayMedia(
                 f"/api/frigate/{identifier.frigate_instance_id}/{server_path}",
                 identifier.mime_type,
@@ -654,7 +654,7 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
             )
 
         if isinstance(identifier, RecordingIdentifier):
-            path = identifier.get_frigate_server_path()
+            path = identifier.get_integration_proxy_path()
             try:
                 recordings_folder = await self._get_client(identifier).async_get_path(
                     path
@@ -781,6 +781,21 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
     ) -> BrowseMediaSource:
         children = []
         for event in events:
+            start_time = event.get("start_time")
+            end_time = event.get("end_time")
+            if start_time is None:
+                continue
+
+            if end_time is None:
+                # Events that are in progress will not yet have an end_time, so
+                # the duration is shown as the current time minus the start
+                # time.
+                duration = int(
+                    dt.datetime.now(DEFAULT_TIME_ZONE).timestamp() - start_time
+                )
+            else:
+                duration = int(end_time - start_time)
+
             children.append(
                 BrowseMediaSource(
                     domain=DOMAIN,
@@ -792,7 +807,7 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
                     ),
                     media_class=identifier.media_class,
                     media_content_type=identifier.media_type,
-                    title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{int(event['end_time']-event['start_time'])}s, {event['label'].capitalize()} {int(event['top_score']*100)}%]",
+                    title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{duration}s, {event['label'].capitalize()} {int(event['top_score']*100)}%]",
                     can_play=identifier.media_type == MEDIA_TYPE_VIDEO,
                     can_expand=False,
                     thumbnail=f"data:image/jpeg;base64,{event['thumbnail']}",

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -100,7 +100,7 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
             return get_config_entry_for_frigate_instance_id(hass, frigate_instance_id)
         return get_default_config_entry(hass)
 
-    def _create_path(self, path: str, **kwargs: Any) -> str | None:
+    def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""
         raise NotImplementedError  # pragma: no cover
 
@@ -125,7 +125,6 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
     async def _handle_request(
         self,
         request: web.Request,
-        path: str,
         frigate_instance_id: str | None = None,
         **kwargs: Any,
     ) -> web.Response | web.StreamResponse:
@@ -137,7 +136,7 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
         if not self._permit_request(request, config_entry):
             return web.Response(status=HTTPStatus.FORBIDDEN)
 
-        full_path = self._create_path(path=path, **kwargs)
+        full_path = self._create_path(**kwargs)
         if not full_path:
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
@@ -176,14 +175,14 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
 class SnapshotsProxyView(ProxyView):
     """A proxy for snapshots."""
 
-    url = "/api/frigate/{frigate_instance_id:.+}/clips/{path:.*}"
-    extra_urls = ["/api/frigate/clips/{path:.*}"]
+    url = "/api/frigate/{frigate_instance_id:.+}/snapshot/{eventid:.*}"
+    extra_urls = ["/api/frigate/snapshot/{eventid:.*}"]
 
     name = "api:frigate:snapshots"
 
-    def _create_path(self, path: str, **kwargs: Any) -> str:
+    def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""
-        return f"clips/{path}"
+        return f"api/events/{kwargs['eventid']}/snapshot.jpg"
 
 
 class NotificationsProxyView(ProxyView):
@@ -195,9 +194,9 @@ class NotificationsProxyView(ProxyView):
     name = "api:frigate:notification"
     requires_auth = False
 
-    def _create_path(self, path: str, **kwargs: Any) -> str | None:
+    def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""
-        event_id = kwargs["event_id"]
+        path, event_id = kwargs["path"], kwargs["event_id"]
         if path == "thumbnail.jpg":
             return f"api/events/{event_id}/thumbnail.jpg"
 
@@ -221,11 +220,9 @@ class VodProxyView(ProxyView):
 
     name = "api:frigate:vod:mainfest"
 
-    def _create_path(self, path: str, **kwargs: Any) -> str | None:
+    def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""
-        manifest = kwargs["manifest"]
-
-        return f"vod/{path}/{manifest}.m3u8"
+        return f"vod/{kwargs['path']}/{kwargs['manifest']}.m3u8"
 
 
 class VodSegmentProxyView(ProxyView):
@@ -237,11 +234,9 @@ class VodSegmentProxyView(ProxyView):
     name = "api:frigate:vod:segment"
     requires_auth = False
 
-    def _create_path(self, path: str, **kwargs: Any) -> str | None:
+    def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""
-        segment = kwargs["segment"]
-
-        return f"vod/{path}/{segment}.ts"
+        return f"vod/{kwargs['path']}/{kwargs['segment']}.ts"
 
     async def _async_validate_signed_manifest(self, request: web.Request) -> bool:
         """Validate the signature for the manifest of this segment."""
@@ -307,7 +302,6 @@ class WebsocketProxyView(ProxyView):
     async def _handle_request(
         self,
         request: web.Request,
-        path: str,
         frigate_instance_id: str | None = None,
         **kwargs: Any,
     ) -> web.Response | web.StreamResponse:
@@ -320,7 +314,7 @@ class WebsocketProxyView(ProxyView):
         if not self._permit_request(request, config_entry):
             return web.Response(status=HTTPStatus.FORBIDDEN)
 
-        full_path = self._create_path(path=path, **kwargs)
+        full_path = self._create_path(**kwargs)
         if not full_path:
             return web.Response(status=HTTPStatus.NOT_FOUND)
 
@@ -369,9 +363,9 @@ class JSMPEGProxyView(WebsocketProxyView):
 
     name = "api:frigate:jsmpeg"
 
-    def _create_path(self, path: str, **kwargs: Any) -> str | None:
+    def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""
-        return f"live/{path}"
+        return f"live/{kwargs['path']}"
 
 
 def _init_header(request: web.Request) -> CIMultiDict | dict[str, str]:


### PR DESCRIPTION
* Adapts the integration to work with long-running "in-progress" events (i.e. no end-time).
   * Fixes in media_source to show the duration as (now - start_time) when the end_time isn't available.
   * Fixes the snapshot proxy to use `/api/events/<eventid>/snapshot.jpg` (on the Frigate backend) as the destination of the request, with`/api/frigate/snapshot/<eventid>` as the Home Assistant entry point.
     * By using '/snapshot/' as the entry point, I'd hope to avoid needing to change this again even if the backend path changes (we'd just swap out the destination).
     * An **alternative** choice would be to mirror the Frigate backend path, i.e. the Home Assistant endpoint would be `/api/events/<eventid>/snapshot.jpg` to match the server.
* Closes https://github.com/dermotduffy/frigate-hass-card/issues/204

Warning: Technically this is breaking behavior, as anyone who is depending on the old `/api/frigate/clips/<path>` behavior will be broken, but I'm not aware of that path being especially in the wild as it's only intended purpose that I'm aware of is for the integration itself (via the media browser).