### PR TITLE
use retain=False for command topic

### DIFF
--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -131,7 +131,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             self._command_topic,
             "ON",
             0,
-            True,
+            False,
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -141,7 +141,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             self._command_topic,
             "OFF",
             0,
-            True,
+            False,
         )
 
     @property

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -85,7 +85,7 @@ async def test_switch_turn_on(hass: HomeAssistant, mqtt_mock: Any) -> None:
         blocking=True,
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "frigate/front_door/detect/set", "ON", 0, True
+        "frigate/front_door/detect/set", "ON", 0, False
     )
 
 
@@ -103,7 +103,7 @@ async def test_switch_turn_off(hass: HomeAssistant, mqtt_mock: Any) -> None:
         blocking=True,
     )
     mqtt_mock.async_publish.assert_called_once_with(
-        "frigate/front_door/detect/set", "OFF", 0, True
+        "frigate/front_door/detect/set", "OFF", 0, False
     )
 
 


### PR DESCRIPTION
Several users have experienced the frigate switches turning off unexpectedly. I think this is due to retain=True for the command topic. In Frigate's code, retain is only ever set to retain on the state topic.