### PR TITLE
Make async_sign_path backwards compatible

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -182,9 +182,9 @@ async def test_vod_segment_proxy(
     refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
     signed_path = async_sign_path(
         hass,
-        refresh_token.id,
         "/api/frigate/vod/present/segment.ts",
         timedelta(seconds=5),
+        refresh_token_id=refresh_token.id,
     )
 
     resp = await hass_client_local_frigate.get(signed_path)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -181,9 +181,9 @@ async def test_vod_segment_proxy(
 
     refresh_token = await hass.auth.async_validate_access_token(hass_access_token)
     signed_path = async_sign_path(
-        hass,
-        "/api/frigate/vod/present/segment.ts",
-        timedelta(seconds=5),
+        hass=hass,
+        path="/api/frigate/vod/present/segment.ts",
+        expiration=timedelta(seconds=5),
         refresh_token_id=refresh_token.id,
     )
 


### PR DESCRIPTION
async_sign_path signature is changing in HA 2022.2. This PR will make it compatible with 2022.2 and remains backwards compatible.