### PR TITLE
:sparkles: - Add entity categories

### DIFF
--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -362,3 +362,8 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return self._icon
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Whether or not the entity is enabled by default."""
+        return self._obj_name != "all"

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -129,7 +129,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     @property
     def entity_category(self) -> str:
         """Return the entity category."""
-        return EntityCategory.DIAGNOSTIC
+        return cast(str, EntityCategory.DIAGNOSTIC)
 
 
 class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
@@ -197,7 +197,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
     @property
     def entity_category(self) -> str:
         """Return the entity category."""
-        return EntityCategory.DIAGNOSTIC
+        return cast(str, EntityCategory.DIAGNOSTIC)
 
 
 class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
@@ -271,7 +271,7 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     @property
     def entity_category(self) -> str:
         """Return the entity category."""
-        return EntityCategory.DIAGNOSTIC
+        return cast(str, EntityCategory.DIAGNOSTIC)
 
 
 class FrigateObjectCountSensor(FrigateMQTTEntity):

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -81,6 +81,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         """Construct a FrigateFpsSensor."""
         FrigateEntity.__init__(self, config_entry)
         CoordinatorEntity.__init__(self, coordinator)
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -126,11 +127,6 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         """Return the icon of the sensor."""
         return ICON_SPEEDOMETER
 
-    @property
-    def entity_category(self) -> str:
-        """Return the entity category."""
-        return cast(str, EntityCategory.DIAGNOSTIC)
-
 
 class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Detector Speed class."""
@@ -145,6 +141,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
         FrigateEntity.__init__(self, config_entry)
         CoordinatorEntity.__init__(self, coordinator)
         self._detector_name = detector_name
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -194,11 +191,6 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
         """Return the icon of the sensor."""
         return ICON_SPEEDOMETER
 
-    @property
-    def entity_category(self) -> str:
-        """Return the entity category."""
-        return cast(str, EntityCategory.DIAGNOSTIC)
-
 
 class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Camera Fps class."""
@@ -215,6 +207,7 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         CoordinatorEntity.__init__(self, coordinator)
         self._cam_name = cam_name
         self._fps_type = fps_type
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -267,11 +260,6 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return ICON_SPEEDOMETER
-
-    @property
-    def entity_category(self) -> str:
-        """Return the entity category."""
-        return cast(str, EntityCategory.DIAGNOSTIC)
 
 
 class FrigateObjectCountSensor(FrigateMQTTEntity):

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -81,7 +81,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         """Construct a FrigateFpsSensor."""
         FrigateEntity.__init__(self, config_entry)
         CoordinatorEntity.__init__(self, coordinator)
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -141,7 +141,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
         FrigateEntity.__init__(self, config_entry)
         CoordinatorEntity.__init__(self, coordinator)
         self._detector_name = detector_name
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -207,7 +207,7 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         CoordinatorEntity.__init__(self, coordinator)
         self._cam_name = cam_name
         self._fps_type = fps_type
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -75,13 +75,14 @@ async def async_setup_entry(
 class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Sensor class."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(
         self, coordinator: FrigateDataUpdateCoordinator, config_entry: ConfigEntry
     ) -> None:
         """Construct a FrigateFpsSensor."""
         FrigateEntity.__init__(self, config_entry)
         CoordinatorEntity.__init__(self, coordinator)
-        _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -131,6 +132,8 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
 class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Detector Speed class."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(
         self,
         coordinator: FrigateDataUpdateCoordinator,
@@ -141,7 +144,6 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
         FrigateEntity.__init__(self, config_entry)
         CoordinatorEntity.__init__(self, coordinator)
         self._detector_name = detector_name
-        _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:
@@ -195,6 +197,8 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
 class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Camera Fps class."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def __init__(
         self,
         coordinator: FrigateDataUpdateCoordinator,
@@ -207,7 +211,6 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         CoordinatorEntity.__init__(self, coordinator)
         self._cam_name = cam_name
         self._fps_type = fps_type
-        _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -126,6 +126,11 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
         """Return the icon of the sensor."""
         return ICON_SPEEDOMETER
 
+    @property
+    def entity_category(self) -> str:
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
+
 
 class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     """Frigate Detector Speed class."""
@@ -188,6 +193,11 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return ICON_SPEEDOMETER
+
+    @property
+    def entity_category(self) -> str:
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
 
 class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
@@ -257,6 +267,11 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return ICON_SPEEDOMETER
+
+    @property
+    def entity_category(self) -> str:
+        """Return the entity category."""
+        return EntityCategory.DIAGNOSTIC
 
 
 class FrigateObjectCountSensor(FrigateMQTTEntity):
@@ -347,8 +362,3 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return self._icon
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Whether or not the entity is enabled by default."""
-        return self._obj_name != "all"

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -152,4 +152,4 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
     @property
     def entity_category(self) -> str:
         """Return the entity category."""
-        return EntityCategory.CONFIG
+        return cast(str, EntityCategory.CONFIG)

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -67,7 +67,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             f"{frigate_config['mqtt']['topic_prefix']}"
             f"/{self._cam_name}/{self._switch_name}/set"
         )
-        self._attr_entity_category = EntityCategory.CONFIG
+        _attr_entity_category = EntityCategory.CONFIG
 
         if self._switch_name == "snapshots":
             self._icon = ICON_IMAGE_MULTIPLE

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity
@@ -67,6 +67,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             f"{frigate_config['mqtt']['topic_prefix']}"
             f"/{self._cam_name}/{self._switch_name}/set"
         )
+        self._attr_entity_category = EntityCategory.CONFIG
 
         if self._switch_name == "snapshots":
             self._icon = ICON_IMAGE_MULTIPLE
@@ -148,8 +149,3 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return self._icon
-
-    @property
-    def entity_category(self) -> str:
-        """Return the entity category."""
-        return cast(str, EntityCategory.CONFIG)

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -8,7 +8,7 @@ from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
@@ -148,3 +148,8 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
     def icon(self) -> str:
         """Return the icon of the sensor."""
         return self._icon
+
+    @property
+    def entity_category(self) -> str:
+        """Return the entity category."""
+        return EntityCategory.CONFIG

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -51,6 +51,8 @@ async def async_setup_entry(
 class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
     """Frigate Switch class."""
 
+    _attr_entity_category = EntityCategory.CONFIG
+
     def __init__(
         self,
         config_entry: ConfigEntry,
@@ -67,7 +69,6 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             f"{frigate_config['mqtt']['topic_prefix']}"
             f"/{self._cam_name}/{self._switch_name}/set"
         )
-        _attr_entity_category = EntityCategory.CONFIG
 
         if self._switch_name == "snapshots":
             self._icon = ICON_IMAGE_MULTIPLE

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity


### PR DESCRIPTION
This would organize the entities created a little bit further, with the "Detect", "Recordings", and "Snapshots" switches being categorized under "Configuration", and the various FPS sensors being under "Diagnostics". Camera entities, including the snapshots, and the motion and tracked objects sensors will stay under "Sensors".