### PR TITLE
:sparkles: - Add device configuration URLs

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -164,6 +164,15 @@ def get_cameras_and_zones(config: dict[str, Any]) -> set[str]:
     return cameras_zones
 
 
+def get_zones(config: dict[str, Any]) -> set[str]:
+    """Get zones."""
+    cameras_zones = set()
+    for camera in config.get("cameras", {}).keys():
+        for zone in config["cameras"][camera].get("zones", {}).keys():
+            cameras_zones.add(zone)
+    return cameras_zones
+
+
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up this integration using YAML is not supported."""
     integration = await async_get_integration(hass, DOMAIN)

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -16,11 +16,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import (
     FrigateMQTTEntity,
     ReceiveMessage,
-    get_zones,
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_zones,
 )
 from .const import ATTR_CONFIG, DOMAIN, NAME
 

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -95,14 +95,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            )
-            + (
-                "/cameras/" + self._cam_name
-                if self._cam_name not in get_zones(self._frigate_config)
-                else ""
-            ),
+            "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_URL
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL
+from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -95,7 +95,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL]
+            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
             + (
                 "/cameras/" + self._cam_name
                 if self._cam_name not in get_zones(self._frigate_config)

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -9,12 +9,14 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import (
     FrigateMQTTEntity,
     ReceiveMessage,
+    get_zones,
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
@@ -52,6 +54,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
         self._cam_name = cam_name
         self._obj_name = obj_name
         self._is_on = False
+        self._frigate_config = frigate_config
 
         super().__init__(
             config_entry,
@@ -92,6 +95,12 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL]
+            + (
+                "/cameras/" + self._cam_name
+                if self._cam_name not in get_zones(self._frigate_config)
+                else ""
+            ),
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -95,7 +95,9 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
+            "configuration_url": self._config_entry.data.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            )
             + (
                 "/cameras/" + self._cam_name
                 if self._cam_name not in get_zones(self._frigate_config)

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -11,7 +11,7 @@ from yarl import URL
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_URL
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -111,6 +111,7 @@ class FrigateCamera(FrigateEntity, Camera):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
+            "configuration_url": self._url + "/cameras/" + self._cam_name,
             "manufacturer": NAME,
         }
 
@@ -198,6 +199,9 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, Camera):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL]
+            + "/cameras/"
+            + self._cam_name,
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -11,7 +11,7 @@ from yarl import URL
 
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL
+from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
@@ -199,7 +199,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, Camera):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL]
+            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
             + "/cameras/"
             + self._cam_name,
             "manufacturer": NAME,

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -111,7 +111,7 @@ class FrigateCamera(FrigateEntity, Camera):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._url + "/cameras/" + self._cam_name,
+            "configuration_url": f"{self._url}/cameras/{self._cam_name}",
             "manufacturer": NAME,
         }
 
@@ -199,11 +199,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, Camera):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            )
-            + "/cameras/"
-            + self._cam_name,
+            "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -199,7 +199,9 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, Camera):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
+            "configuration_url": self._config_entry.data.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            )
             + "/cameras/"
             + self._cam_name,
             "manufacturer": NAME,

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -15,6 +16,7 @@ from . import (
     FrigateEntity,
     FrigateMQTTEntity,
     ReceiveMessage,
+    get_zones,
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
@@ -96,6 +98,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL],
             "manufacturer": NAME,
         }
 
@@ -155,6 +158,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL],
             "manufacturer": NAME,
         }
 
@@ -225,6 +229,9 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL]
+            + "/cameras/"
+            + self._cam_name,
             "manufacturer": NAME,
         }
 
@@ -273,6 +280,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
         self._cam_name = cam_name
         self._obj_name = obj_name
         self._state = 0
+        self._frigate_config = frigate_config
 
         if self._obj_name == "person":
             self._icon = ICON_PERSON
@@ -325,6 +333,12 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL]
+            + (
+                "/cameras/" + self._cam_name
+                if self._cam_name not in get_zones(self._frigate_config)
+                else ""
+            ),
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -16,11 +16,11 @@ from . import (
     FrigateEntity,
     FrigateMQTTEntity,
     ReceiveMessage,
-    get_zones,
     get_cameras_zones_and_objects,
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_zones,
 )
 from .const import (
     ATTR_CONFIG,

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL
+from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -98,7 +98,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL],
+            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, "")),
             "manufacturer": NAME,
         }
 
@@ -158,7 +158,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL],
+            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, "")),
             "manufacturer": NAME,
         }
 
@@ -229,7 +229,7 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL]
+            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
             + "/cameras/"
             + self._cam_name,
             "manufacturer": NAME,
@@ -333,7 +333,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL]
+            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
             + (
                 "/cameras/" + self._cam_name
                 if self._cam_name not in get_zones(self._frigate_config)

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_URL
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -98,9 +98,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            ),
+            "configuration_url": self._config_entry.data.get(CONF_URL),
             "manufacturer": NAME,
         }
 
@@ -160,9 +158,7 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            ),
+            "configuration_url": self._config_entry.data.get(CONF_URL),
             "manufacturer": NAME,
         }
 
@@ -233,11 +229,7 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            )
-            + "/cameras/"
-            + self._cam_name,
+            "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
             "manufacturer": NAME,
         }
 
@@ -339,14 +331,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            )
-            + (
-                "/cameras/" + self._cam_name
-                if self._cam_name not in get_zones(self._frigate_config)
-                else ""
-            ),
+            "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -98,7 +98,9 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, "")),
+            "configuration_url": self._config_entry.data.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            ),
             "manufacturer": NAME,
         }
 
@@ -158,7 +160,9 @@ class DetectorSpeedSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[mis
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
             "name": NAME,
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, "")),
+            "configuration_url": self._config_entry.data.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            ),
             "manufacturer": NAME,
         }
 
@@ -229,7 +233,9 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
+            "configuration_url": self._config_entry.data.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            )
             + "/cameras/"
             + self._cam_name,
             "manufacturer": NAME,
@@ -333,7 +339,9 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(CONF_URL, self._config_entry.data.get(CONF_HOST, ""))
+            "configuration_url": self._config_entry.data.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            )
             + (
                 "/cameras/" + self._cam_name
                 if self._cam_name not in get_zones(self._frigate_config)

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -112,11 +112,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data.get(
-                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
-            )
-            + "/cameras/"
-            + self._cam_name,
+            "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL
+from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -18,7 +18,6 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
-    get_zones,
 )
 from .const import (
     ATTR_CONFIG,
@@ -113,7 +112,9 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.data[CONF_URL]
+            "configuration_url": self._config_entry.get(
+                CONF_URL, self._config_entry.data.get(CONF_HOST, "")
+            )
             + "/cameras/"
             + self._cam_name,
             "manufacturer": NAME,

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -112,7 +112,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
-            "configuration_url": self._config_entry.get(
+            "configuration_url": self._config_entry.data.get(
                 CONF_URL, self._config_entry.data.get(CONF_HOST, "")
             )
             + "/cameras/"

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -7,6 +7,7 @@ from typing import Any
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -17,6 +18,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_zones,
 )
 from .const import (
     ATTR_CONFIG,
@@ -111,6 +113,9 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):  # type: ignore[misc]
             "via_device": get_frigate_device_identifier(self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
+            "configuration_url": self._config_entry.data[CONF_URL]
+            + "/cameras/"
+            + self._cam_name,
             "manufacturer": NAME,
         }
 

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_URL
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
This one adds the "Visit Device" button to each of the device pages! For specific cameras, it should open to that camera's page in the Frigate UI, but for the "master" device and zones, it will open to the main Frigate homepage.