### PR TITLE
💥 Support for general motion sensor

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -88,6 +88,16 @@ def get_friendly_name(name: str) -> str:
     return name.replace("_", " ").title()
 
 
+def get_cameras(config: dict[str, Any]) -> set[str]:
+    """Get cameras."""
+    cameras = set()
+
+    for cam_name, _ in config["cameras"].items():
+        cameras.add(cam_name)
+
+    return cameras
+
+
 def get_cameras_and_objects(
     config: dict[str, Any], include_all: bool = True
 ) -> set[tuple[str, str]]:

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -242,7 +242,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_options.pop(CONF_CAMERA_STATIC_IMAGE_HEIGHT)
         hass.config_entries.async_update_entry(entry, options=new_options)
 
-    # cleanup object_motion sensors.
+    # Cleanup object_motion sensors (replaced with occupancy sensors).
     for cam_name, obj_name in get_cameras_zones_and_objects(config):
         unique_id = get_frigate_entity_unique_id(
             entry.entry_id,
@@ -312,7 +312,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
             converters: Final[dict[re.Pattern, Callable[[re.Match], list[str]]]] = {
                 re.compile(rf"^{DOMAIN}_(?P<cam_obj>\S+)_binary_sensor$"): lambda m: [
-                    "motion_sensor",
+                    "occupancy_sensor",
                     m.group("cam_obj"),
                 ],
                 re.compile(rf"^{DOMAIN}_(?P<cam>\S+)_camera$"): lambda m: [

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -242,6 +242,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_options.pop(CONF_CAMERA_STATIC_IMAGE_HEIGHT)
         hass.config_entries.async_update_entry(entry, options=new_options)
 
+    # cleanup object_motion sensors.
+    for cam_name, obj_name in get_cameras_zones_and_objects(config):
+        unique_id = get_frigate_entity_unique_id(
+            entry.entry_id,
+            "motion_sensor",
+            f"{cam_name}_{obj_name}",
+        )
+        entity_id = entity_registry.async_get_entity_id(
+            "motion_sensor", DOMAIN, unique_id
+        )
+        if entity_id:
+            entity_registry.async_remove(entity_id)
+
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_entry_updated))
 

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -250,7 +250,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             f"{cam_name}_{obj_name}",
         )
         entity_id = entity_registry.async_get_entity_id(
-            "motion_sensor", DOMAIN, unique_id
+            "binary_sensor", DOMAIN, unique_id
         )
         if entity_id:
             entity_registry.async_remove(entity_id)

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
+    DEVICE_CLASS_PRESENCE,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -56,7 +57,7 @@ async def async_setup_entry(
 
 
 class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]
-    """Frigate Motion Sensor class."""
+    """Frigate Presence Sensor class."""
 
     def __init__(
         self,
@@ -65,7 +66,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
         cam_name: str,
         obj_name: str,
     ) -> None:
-        """Construct a new FrigateMotionSensor."""
+        """Construct a new FrigateObjectPresenceSensor."""
         self._cam_name = cam_name
         self._obj_name = obj_name
         self._is_on = False
@@ -117,7 +118,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{get_friendly_name(self._cam_name)} {self._obj_name} Motion".title()
+        return f"{get_friendly_name(self._cam_name)} {self._obj_name} Presence".title()
 
     @property
     def is_on(self) -> bool:
@@ -132,7 +133,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
     @property
     def device_class(self) -> str:
         """Return the device class."""
-        return cast(str, DEVICE_CLASS_MOTION)
+        return cast(str, DEVICE_CLASS_PRESENCE)
 
 
 class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -34,13 +34,13 @@ async def async_setup_entry(
     frigate_config = hass.data[DOMAIN][entry.entry_id][ATTR_CONFIG]
     async_add_entities(
         [
-            FrigateMotionSensor(entry, frigate_config, cam_name, obj)
+            FrigateObjectPresenceSensor(entry, frigate_config, cam_name, obj)
             for cam_name, obj in get_cameras_zones_and_objects(frigate_config)
         ]
     )
 
 
-class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]
+class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]
     """Frigate Motion Sensor class."""
 
     def __init__(

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -196,7 +196,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{get_friendly_name(self._cam_name)} General Motion".title()
+        return f"{get_friendly_name(self._cam_name)} Motion".title()
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
     entities = []
 
     # add object sensors for cameras and zones
-    entities.append(
+    entities.extend(
         [
             FrigateObjectPresenceSensor(entry, frigate_config, cam_name, obj)
             for cam_name, obj in get_cameras_zones_and_objects(frigate_config)
@@ -45,7 +45,7 @@ async def async_setup_entry(
     )
 
     # add generic motion sensors for cameras
-    entities.append(
+    entities.extend(
         [
             FrigateMotionSensor(entry, frigate_config, cam_name)
             for cam_name in get_cameras(frigate_config)

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -156,7 +156,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
             {
                 "topic": (
                     f"{frigate_config['mqtt']['topic_prefix']}"
-                    f"/{self._cam_name}/motion/detected"
+                    f"/{self._cam_name}/motion"
                 )
             },
         )

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -164,10 +164,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignor
     @callback  # type: ignore[misc]
     def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
-        try:
-            self._is_on = bool(msg.payload)
-        except ValueError:
-            self._is_on = False
+        self._is_on = msg.payload == "ON"
         super()._state_message_received(msg)
 
     @property

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_PRESENCE,
+    DEVICE_CLASS_OCCUPANCY,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -40,7 +40,7 @@ async def async_setup_entry(
     # add object sensors for cameras and zones
     entities.extend(
         [
-            FrigateObjectPresenceSensor(entry, frigate_config, cam_name, obj)
+            FrigateObjectOccupancySensor(entry, frigate_config, cam_name, obj)
             for cam_name, obj in get_cameras_zones_and_objects(frigate_config)
         ]
     )
@@ -56,8 +56,8 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]
-    """Frigate Presence Sensor class."""
+class FrigateObjectOccupancySensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]
+    """Frigate Occupancy Sensor class."""
 
     def __init__(
         self,
@@ -66,7 +66,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
         cam_name: str,
         obj_name: str,
     ) -> None:
-        """Construct a new FrigateObjectPresenceSensor."""
+        """Construct a new FrigateObjectOccupancySensor."""
         self._cam_name = cam_name
         self._obj_name = obj_name
         self._is_on = False
@@ -97,7 +97,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
         """Return a unique ID for this entity."""
         return get_frigate_entity_unique_id(
             self._config_entry.entry_id,
-            "presence_sensor",
+            "occupancy_sensor",
             f"{self._cam_name}_{self._obj_name}",
         )
 
@@ -118,7 +118,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{get_friendly_name(self._cam_name)} {self._obj_name} Presence".title()
+        return f"{get_friendly_name(self._cam_name)} {self._obj_name} Occupancy".title()
 
     @property
     def is_on(self) -> bool:
@@ -133,7 +133,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
     @property
     def device_class(self) -> str:
         """Return the device class."""
-        return cast(str, DEVICE_CLASS_PRESENCE)
+        return cast(str, DEVICE_CLASS_OCCUPANCY)
 
 
 class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):  # type: ignore[misc]

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -97,7 +97,7 @@ class FrigateObjectPresenceSensor(FrigateMQTTEntity, BinarySensorEntity):  # typ
         """Return a unique ID for this entity."""
         return get_frigate_entity_unique_id(
             self._config_entry.entry_id,
-            "motion_sensor",
+            "presence_sensor",
             f"{self._cam_name}_{self._obj_name}",
         )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,11 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
-TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = (
-    "binary_sensor.front_door_general_motion"
-)
-TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID = (
-    "binary_sensor.front_door_person_motion"
+TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = "binary_sensor.front_door_motion"
+TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID = (
+    "binary_sensor.front_door_person_presence"
 )
 TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID = (
     "binary_sensor.steps_person_presence"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,8 +18,10 @@ TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = (
 TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID = (
     "binary_sensor.front_door_person_motion"
 )
-TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID = "binary_sensor.steps_person_motion"
-TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID = "binary_sensor.steps_all_motion"
+TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID = (
+    "binary_sensor.steps_person_presence"
+)
+TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID = "binary_sensor.steps_all_presence"
 TEST_CAMERA_FRONT_DOOR_ENTITY_ID = "camera.front_door"
 TEST_CAMERA_FRONT_DOOR_PERSON_ENTITY_ID = "camera.front_door_person"
 TEST_SWITCH_FRONT_DOOR_DETECT_ENTITY_ID = "switch.front_door_detect"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
+TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = "binary_sensor.front_door_motion"
 TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID = (
     "binary_sensor.front_door_person_motion"
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,13 +13,13 @@ from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
 TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = "binary_sensor.front_door_motion"
-TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID = (
-    "binary_sensor.front_door_person_presence"
+TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID = (
+    "binary_sensor.front_door_person_occupancy"
 )
-TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID = (
-    "binary_sensor.steps_person_presence"
+TEST_BINARY_SENSOR_STEPS_PERSON_OCCUPANCY_ENTITY_ID = (
+    "binary_sensor.steps_person_occupancy"
 )
-TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID = "binary_sensor.steps_all_presence"
+TEST_BINARY_SENSOR_STEPS_ALL_OCCUPANCY_ENTITY_ID = "binary_sensor.steps_all_occupancy"
 TEST_CAMERA_FRONT_DOOR_ENTITY_ID = "camera.front_door"
 TEST_CAMERA_FRONT_DOOR_PERSON_ENTITY_ID = "camera.front_door_person"
 TEST_SWITCH_FRONT_DOOR_DETECT_ENTITY_ID = "switch.front_door_detect"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
-TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = "binary_sensor.front_door_motion"
+TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID = (
+    "binary_sensor.front_door_general_motion"
+)
 TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID = (
     "binary_sensor.front_door_person_motion"
 )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -16,8 +16,8 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from . import (
     TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID,
     TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID,
-    TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID,
-    TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID,
+    TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID,
+    TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID,
     TEST_CONFIG_ENTRY_ID,
     TEST_SERVER_VERSION,
     create_mock_frigate_client,
@@ -57,7 +57,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     # Verify the steps (zone) motion sensor works.
     async_fire_mqtt_message(hass, "frigate/steps/person", "1")
     await hass.async_block_till_done()
-    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID)
+    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "on"
 
@@ -99,7 +99,7 @@ async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:
     "camerazone_entity",
     [
         ("front_door", TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID),
-        ("steps", TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID),
+        ("steps", TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID),
     ],
 )
 async def test_binary_sensor_device_info(
@@ -157,15 +157,15 @@ async def test_binary_sensor_all_can_be_enabled(hass: HomeAssistant) -> None:
     entity_registry = er.async_get(hass)
 
     # Test original entity is disabled as expected
-    entry = entity_registry.async_get(TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID)
+    entry = entity_registry.async_get(TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID)
     assert entry
     assert entry.disabled
     assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
-    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID)
+    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID)
     assert not entity_state
 
     # Update and test that entity is now enabled
     updated_entry = entity_registry.async_update_entity(
-        TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID, disabled_by=None
+        TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID, disabled_by=None
     )
     assert not updated_entry.disabled

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -112,7 +112,7 @@ async def test_binary_sensor_motion_can_be_enabled(hass: HomeAssistant) -> None:
 
             entity_state = hass.states.get(disabled_entity_id)
             assert entity_state
-            assert entity_state == "off"
+            assert entity_state.state == "off"
 
 
 async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,9 +15,9 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID,
-    TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID,
-    TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID,
-    TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID,
+    TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID,
+    TEST_BINARY_SENSOR_STEPS_ALL_OCCUPANCY_ENTITY_ID,
+    TEST_BINARY_SENSOR_STEPS_PERSON_OCCUPANCY_ENTITY_ID,
     TEST_CONFIG_ENTRY_ID,
     TEST_SERVER_VERSION,
     create_mock_frigate_client,
@@ -27,12 +27,12 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_presence_binary_sensor_setup(hass: HomeAssistant) -> None:
-    """Verify a successful presence binary sensor setup."""
+async def test_occupancy_binary_sensor_setup(hass: HomeAssistant) -> None:
+    """Verify a successful occupancy binary sensor setup."""
     await setup_mock_frigate_config_entry(hass)
 
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "unavailable"
@@ -40,7 +40,7 @@ async def test_presence_binary_sensor_setup(hass: HomeAssistant) -> None:
     async_fire_mqtt_message(hass, "frigate/available", "online")
     await hass.async_block_till_done()
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "off"
@@ -48,7 +48,7 @@ async def test_presence_binary_sensor_setup(hass: HomeAssistant) -> None:
     async_fire_mqtt_message(hass, "frigate/front_door/person", "1")
     await hass.async_block_till_done()
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "on"
@@ -56,21 +56,21 @@ async def test_presence_binary_sensor_setup(hass: HomeAssistant) -> None:
     # Verify the steps (zone) motion sensor works.
     async_fire_mqtt_message(hass, "frigate/steps/person", "1")
     await hass.async_block_till_done()
-    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID)
+    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_PERSON_OCCUPANCY_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "on"
 
     async_fire_mqtt_message(hass, "frigate/front_door/person", "not_an_int")
     await hass.async_block_till_done()
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "off"
 
     async_fire_mqtt_message(hass, "frigate/available", "offline")
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "unavailable"
@@ -81,14 +81,14 @@ async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:
     client = create_mock_frigate_client()
     client.async_get_stats = AsyncMock(side_effect=FrigateApiClientError)
     await setup_mock_frigate_config_entry(hass, client=client)
-    assert not hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID)
+    assert not hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID)
 
 
 @pytest.mark.parametrize(
     "camerazone_entity",
     [
-        ("front_door", TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID),
-        ("steps", TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID),
+        ("front_door", TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID),
+        ("steps", TEST_BINARY_SENSOR_STEPS_PERSON_OCCUPANCY_ENTITY_ID),
     ],
 )
 async def test_binary_sensor_device_info(
@@ -119,12 +119,12 @@ async def test_binary_sensor_unique_id(hass: HomeAssistant) -> None:
     """Verify entity unique_id(s)."""
     await setup_mock_frigate_config_entry(hass)
     registry_entry = er.async_get(hass).async_get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_OCCUPANCY_ENTITY_ID
     )
     assert registry_entry
     assert (
         registry_entry.unique_id
-        == f"{TEST_CONFIG_ENTRY_ID}:presence_sensor:front_door_person"
+        == f"{TEST_CONFIG_ENTRY_ID}:occupancy_sensor:front_door_person"
     )
 
 
@@ -146,16 +146,16 @@ async def test_binary_sensor_all_can_be_enabled(hass: HomeAssistant) -> None:
     entity_registry = er.async_get(hass)
 
     # Test original entity is disabled as expected
-    entry = entity_registry.async_get(TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID)
+    entry = entity_registry.async_get(TEST_BINARY_SENSOR_STEPS_ALL_OCCUPANCY_ENTITY_ID)
     assert entry
     assert entry.disabled
     assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
-    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID)
+    entity_state = hass.states.get(TEST_BINARY_SENSOR_STEPS_ALL_OCCUPANCY_ENTITY_ID)
     assert not entity_state
 
     # Update and test that entity is now enabled
     updated_entry = entity_registry.async_update_entity(
-        TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID, disabled_by=None
+        TEST_BINARY_SENSOR_STEPS_ALL_OCCUPANCY_ENTITY_ID, disabled_by=None
     )
     assert not updated_entry.disabled
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
+    TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID,
     TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID,
     TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID,
     TEST_BINARY_SENSOR_STEPS_PERSON_MOTION_ENTITY_ID,
@@ -73,6 +74,13 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     )
     assert entity_state
     assert entity_state.state == "unavailable"
+
+    # Verify the general motion sensor works.
+    async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", True)
+    await hass.async_block_till_done()
+    entity_state = hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "on"
 
 
 async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -27,10 +27,9 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
-    """Verify a successful binary sensor setup."""
+async def test_presence_binary_sensor_setup(hass: HomeAssistant) -> None:
+    """Verify a successful presence binary sensor setup."""
     await setup_mock_frigate_config_entry(hass)
-    entity_registry = er.async_get(hass)
 
     entity_state = hass.states.get(
         TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
@@ -76,8 +75,13 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     assert entity_state
     assert entity_state.state == "unavailable"
 
+
+async def test_motion_binary_sensor_setup(hass: HomeAssistant) -> None:
+    """Verify a successful motion binary sensor setup."""
+    entity_registry = er.async_get(hass)
+
     # Verify the general motion sensor works.
-    await entity_registry.async_update_entity(
+    entity_registry.async_update_entity(
         TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID, disabled_by=None
     )
     async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", "True")

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -76,7 +76,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     assert entity_state.state == "unavailable"
 
     # Verify the general motion sensor works.
-    async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", True)
+    async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", "True")
     await hass.async_block_till_done()
     entity_state = hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID)
     assert entity_state

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -110,11 +110,11 @@ async def test_binary_sensor_motion_can_be_enabled(hass: HomeAssistant) -> None:
                 dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
             )
 
-            async_fire_mqtt_message(hass, mqtt_topic, "True")
+            async_fire_mqtt_message(hass, mqtt_topic, "ON")
             await hass.async_block_till_done()
             entity_state = hass.states.get(disabled_entity_id)
             assert entity_state
-            assert entity_state.state == "off"
+            assert entity_state.state == "on"
 
 
 async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     """Verify a successful binary sensor setup."""
     await setup_mock_frigate_config_entry(hass)
+    entity_registry = er.async_get(hass)
 
     entity_state = hass.states.get(
         TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
@@ -76,6 +77,9 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     assert entity_state.state == "unavailable"
 
     # Verify the general motion sensor works.
+    entity_registry.async_update_entity(
+        TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID, disabled_by=None
+    )
     async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", "True")
     await hass.async_block_till_done()
     entity_state = hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import (
     TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID,
-    TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID,
+    TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID,
     TEST_BINARY_SENSOR_STEPS_ALL_PRESENCE_ENTITY_ID,
     TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID,
     TEST_CONFIG_ENTRY_ID,
@@ -33,7 +33,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     entity_registry = er.async_get(hass)
 
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "unavailable"
@@ -41,7 +41,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     async_fire_mqtt_message(hass, "frigate/available", "online")
     await hass.async_block_till_done()
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "off"
@@ -49,7 +49,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     async_fire_mqtt_message(hass, "frigate/front_door/person", "1")
     await hass.async_block_till_done()
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "on"
@@ -64,14 +64,14 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     async_fire_mqtt_message(hass, "frigate/front_door/person", "not_an_int")
     await hass.async_block_till_done()
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "off"
 
     async_fire_mqtt_message(hass, "frigate/available", "offline")
     entity_state = hass.states.get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
     )
     assert entity_state
     assert entity_state.state == "unavailable"
@@ -92,13 +92,13 @@ async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:
     client = create_mock_frigate_client()
     client.async_get_stats = AsyncMock(side_effect=FrigateApiClientError)
     await setup_mock_frigate_config_entry(hass, client=client)
-    assert not hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID)
+    assert not hass.states.get(TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID)
 
 
 @pytest.mark.parametrize(
     "camerazone_entity",
     [
-        ("front_door", TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID),
+        ("front_door", TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID),
         ("steps", TEST_BINARY_SENSOR_STEPS_PERSON_PRESENCE_ENTITY_ID),
     ],
 )
@@ -130,7 +130,7 @@ async def test_binary_sensor_unique_id(hass: HomeAssistant) -> None:
     """Verify entity unique_id(s)."""
     await setup_mock_frigate_config_entry(hass)
     registry_entry = er.async_get(hass).async_get(
-        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_MOTION_ENTITY_ID
+        TEST_BINARY_SENSOR_FRONT_DOOR_PERSON_PRESENCE_ENTITY_ID
     )
     assert registry_entry
     assert (

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -109,11 +109,16 @@ async def test_binary_sensor_motion_can_be_enabled(hass: HomeAssistant) -> None:
                 hass,
                 dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
             )
+            await hass.async_block_till_done()
+
+            async_fire_mqtt_message(hass, "frigate/available", "online")
+            await hass.async_block_till_done()
 
             async_fire_mqtt_message(hass, mqtt_topic, "ON")
             await hass.async_block_till_done()
+
             entity_state = hass.states.get(disabled_entity_id)
-            assert entity_state
+            assert entity_state.state == "on"
 
 
 async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -77,7 +77,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
     assert entity_state.state == "unavailable"
 
     # Verify the general motion sensor works.
-    entity_registry.async_update_entity(
+    await entity_registry.async_update_entity(
         TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID, disabled_by=None
     )
     async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", "True")

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -89,7 +89,7 @@ async def test_binary_sensor_motion_can_be_enabled(hass: HomeAssistant) -> None:
 
     entity_registry = er.async_get(hass)
     expected_results = {
-        TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID: "frigate/front_door/motion/detected",
+        TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID: "frigate/front_door/motion",
     }
 
     # Keep the patch in place to ensure that coordinator updates that are
@@ -114,7 +114,6 @@ async def test_binary_sensor_motion_can_be_enabled(hass: HomeAssistant) -> None:
             await hass.async_block_till_done()
             entity_state = hass.states.get(disabled_entity_id)
             assert entity_state
-            assert entity_state.state == "on"
 
 
 async def test_binary_sensor_api_call_failed(hass: HomeAssistant) -> None:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -78,7 +78,7 @@ async def test_binary_sensor_setup(hass: HomeAssistant) -> None:
 
     # Verify the general motion sensor works.
     entity_registry.async_update_entity(
-        TEST_BINARY_SENSOR_STEPS_ALL_MOTION_ENTITY_ID, disabled_by=None
+        TEST_BINARY_SENSOR_FRONT_DOOR_MOTION_ENTITY_ID, disabled_by=None
     )
     async_fire_mqtt_message(hass, "frigate/front_door/motion/detected", "True")
     await hass.async_block_till_done()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -151,7 +151,7 @@ async def test_entry_migration_v1_to_v2(hass: HomeAssistant) -> None:
 
     # Ensure all the new transformed entity unique ids are present.
     new_unique_ids = [
-        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"),
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:occupancy_sensor:front_door_person"),
         ("camera", f"{TEST_CONFIG_ENTRY_ID}:camera:front_door"),
         ("camera", f"{TEST_CONFIG_ENTRY_ID}:camera_snapshots:front_door_person"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_camera"),
@@ -166,7 +166,7 @@ async def test_entry_migration_v1_to_v2(hass: HomeAssistant) -> None:
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_detector_speed:cpu2"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_detection"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_object_count:steps_person"),
-        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:steps_person"),
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:occupancy_sensor:steps_person"),
     ]
     for platform, unique_id in new_unique_ids:
         assert (
@@ -189,7 +189,7 @@ async def test_entry_cleanup_old_clips_switch(hass: HomeAssistant) -> None:
     config_entry.add_to_hass(hass)
 
     old_unique_ids = [
-        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"),
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:occupancy_sensor:front_door_person"),
         ("camera", f"{TEST_CONFIG_ENTRY_ID}:camera:front_door"),
         ("camera", f"{TEST_CONFIG_ENTRY_ID}:camera_snapshots:front_door_person"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_camera"),
@@ -204,7 +204,7 @@ async def test_entry_cleanup_old_clips_switch(hass: HomeAssistant) -> None:
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_detector_speed:cpu2"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_detection"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_object_count:steps_person"),
-        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:steps_person"),
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:occupancy_sensor:steps_person"),
     ]
 
     # Create fake entries with the old unique_ids.
@@ -251,7 +251,7 @@ async def test_entry_cleanup_old_motion_sensor(hass: HomeAssistant) -> None:
 
     config_entry.add_to_hass(hass)
 
-    old_unique_ids = [
+    old_unique_ids = {
         ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"),
         ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:steps_person"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_camera"),
@@ -259,7 +259,8 @@ async def test_entry_cleanup_old_motion_sensor(hass: HomeAssistant) -> None:
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:detection"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_process"),
         ("sensor", f"{TEST_CONFIG_ENTRY_ID}:sensor_fps:front_door_skipped"),
-    ]
+        ("switch", f"{TEST_CONFIG_ENTRY_ID}:switch:front_door_recordings"),
+    }
 
     # Create fake entries with the old unique_ids.
     for platform, unique_id in old_unique_ids:
@@ -272,24 +273,18 @@ async def test_entry_cleanup_old_motion_sensor(hass: HomeAssistant) -> None:
         hass, config_entry=config_entry
     )
 
-    for platform, unique_id in old_unique_ids:
-        if platform == "binary_sensor" and unique_id.endswith("_person"):
-            assert (
-                entity_registry.async_get_entity_id("motion_sensor", DOMAIN, unique_id)
-                is None
-            )
-        else:
-            assert (
-                entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
-                is not None
-            )
+    removed_unique_ids = {
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:front_door_person"),
+        ("binary_sensor", f"{TEST_CONFIG_ENTRY_ID}:motion_sensor:steps_person"),
+    }
 
-    assert (
-        entity_registry.async_get_entity_id(
-            "switch", DOMAIN, f"{TEST_CONFIG_ENTRY_ID}:switch:front_door_recordings"
+    for platform, unique_id in removed_unique_ids:
+        assert entity_registry.async_get_entity_id(platform, DOMAIN, unique_id) is None
+
+    for platform, unique_id in old_unique_ids - removed_unique_ids:
+        assert (
+            entity_registry.async_get_entity_id(platform, DOMAIN, unique_id) is not None
         )
-        is not None
-    )
 
 
 async def test_startup_message(caplog: Any, hass: HomeAssistant) -> None:


### PR DESCRIPTION
# 💥 BREAKING CHANGE 💥

* Renames entities previously known as `binary_sensor.kitchen_person_motion` to `binary_sensor.kitchen_person_occupancy`. The old name was a misnomer. All automations and templates that used the old entity_id must be updated manually.
* Introduces a new motion sensor entity (not associated with objects): `binary_sensor.kitchen_motion`. This entity is disabled by default.

# Motion Sensor

Parent frigate PR: https://github.com/blakeblackshear/frigate/pull/3152

This adds support for a true motion sensor. 

# Open Questions
1. I know (from other integrations / requests) that users will likely not work well with the direct data coming from frigate which will rapidly switch between True / False. Happy to provide specific examples, but it seems users will likely expect this motion sensor to behave in the fashion where it will be set to True on motion and then reset after no motion is seen for some period of time. I am open to suggestions on how to approach / implement this.
2. I'm not super sure about the naming, as the other sensors are already called "motion" despite not being directly related to motion. I think "{cam_name} General Motion" is decent but am open to suggestions.