### PR TITLE
Remove deprecated HACS manifest values

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,13 +1,5 @@
 {
     "hacs": "1.6.0",
     "name": "Frigate",
-    "domains": [
-        "media_browser",
-        "sensor",
-        "camera",
-        "binary_sensor",
-        "switch"
-    ],
-    "iot_class": "Local Push",
     "homeassistant": "2022.4.5"
 }


### PR DESCRIPTION
Hey,

HACS check does not support any more `domains` and `iot_class` in the manifest (hacs.json). And also they are removed from the documentation (https://hacs.xyz/docs/publish/start#hacsjson)

If removing them, HACS action will not provide errors you currently have:
`Error:  <Validation hacs_manifest> failed:  extra keys not allowed @ data['domains']`

And yes, if only remove `domains`, next time it will show a problem with `iot_class`

Have a nice day!

P.S. This was checked on my HA integration: [link to the last checks](https://github.com/Vaskivskyi/ha-asusrouter/actions/workflows/build.yaml)