### PR TITLE
Set use_wallclock_as_timestamps stream option

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -11,6 +11,7 @@ from yarl import URL
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.mqtt import async_publish
+from homeassistant.components.stream import CONF_USE_WALLCLOCK_AS_TIMESTAMPS
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
@@ -108,6 +109,8 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         self._set_motion_topic = (
             f"{frigate_config['mqtt']['topic_prefix']}" f"/{self._cam_name}/motion/set"
         )
+        # Set the use_wallclock_as_timestamps stream option
+        self.stream_options[CONF_USE_WALLCLOCK_AS_TIMESTAMPS] = True
 
         streaming_template = config_entry.options.get(
             CONF_RTMP_URL_TEMPLATE, ""


### PR DESCRIPTION
HA's stream has an unfortunate "feature" where bad timestamps can cause an assertion error, bringing down the whole process. This can be worked around by having HA rewrite the timestamps using ffmpeg's `use_wallclock_as_timestamps` flag.
This problem was encountered by @drthanwho who noticed the issue when rebooting cameras. It appears the rtmp stream is not restarted when the cameras are restarted, so an alternative to this PR may be to set up the nginx rtmp module in frigate with the [play_restart](https://github.com/arut/nginx-rtmp-module/wiki/Directives#play_restart) option set to on.