### PR TITLE
Rename the devcontainer Frigate camera

### DIFF
--- a/.devcontainer/frigate.yml
+++ b/.devcontainer/frigate.yml
@@ -7,7 +7,7 @@ detectors:
 mqtt:
   host: mqtt
 cameras:
-  frigate:
+  big_buck_bunny:
     ffmpeg:
       inputs:
         - path: rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4

--- a/.devcontainer/frigate.yml
+++ b/.devcontainer/frigate.yml
@@ -7,7 +7,7 @@ detectors:
 mqtt:
   host: mqtt
 cameras:
-  demo:
+  frigate:
     ffmpeg:
       inputs:
         - path: rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4


### PR DESCRIPTION
@felipecrs Too many things with 'demo' in the name ;-) Suggest we rename the Frigate camera so the resultant entity in HA is just `camera.frigate`. Opinions?