### PR TITLE
Don't add "all" entity for zone with single label

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -135,7 +135,9 @@ def get_cameras_zones_and_objects(config: dict[str, Any]) -> set[tuple[str, str]
             # add an artificial all label to track
             # all objects for this zone
             # NOTE: only add for zones that contain more than 1 object
-            if len(zone_name_objects) > 1:
+            if (not zone_name_objects and len(camera_objects) > 1) or len(
+                zone_name_objects
+            ) > 1:
                 zone_objects.add((zone_name, "all"))
     return camera_objects.union(zone_objects)
 

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -134,7 +134,9 @@ def get_cameras_zones_and_objects(config: dict[str, Any]) -> set[tuple[str, str]
 
             # add an artificial all label to track
             # all objects for this zone
-            zone_objects.add((zone_name, "all"))
+            # NOTE: only add for zones that contain more than 1 object
+            if len(zone_name_objects) > 1:
+                zone_objects.add((zone_name, "all"))
     return camera_objects.union(zone_objects)
 
 

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -139,6 +139,7 @@ def get_cameras_zones_and_objects(config: dict[str, Any]) -> set[tuple[str, str]
                 zone_name_objects
             ) > 1:
                 zone_objects.add((zone_name, "all"))
+
     return camera_objects.union(zone_objects)
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate import (
+    get_cameras_zones_and_objects,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
 )
@@ -485,3 +486,12 @@ async def test_entry_rename_entities_with_unusual_names(hass: HomeAssistant) -> 
     # Verify the rename has correctly occurred.
     entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, unique_id)
     assert entity_id == "sensor.front_door_person_count"
+
+
+async def test_zone_specific_objects(hass: HomeAssistant) -> None:
+    """Test that all is not inserted to single item object list."""
+
+    config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
+    config["cameras"]["front_door"]["zones"]["steps"]["objects"] = ["person"]
+    labels = get_cameras_zones_and_objects(config)
+    assert "all" not in labels

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -494,4 +494,4 @@ async def test_zone_specific_objects(hass: HomeAssistant) -> None:
     config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     config["cameras"]["front_door"]["zones"]["steps"]["objects"] = ["person"]
     labels = get_cameras_zones_and_objects(config)
-    assert "all" not in labels
+    assert ("steps", "all") not in labels


### PR DESCRIPTION
Noticed that "all" is created for zones even if they have only one label which seems a bit confusing, so this keeps them from being created.

![Screen Shot 2022-06-18 at 14 00 16 PM](https://user-images.githubusercontent.com/14866235/174455777-420e1a53-8fde-441f-97c1-7cde1b4336f2.png)
