### PR TITLE
Prevent assert from cors library on preparing response to cors request

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -436,6 +436,12 @@ def _response_header(response: aiohttp.ClientResponse) -> dict[str, str]:
             # hdrs.CONTENT_LENGTH,
             hdrs.CONTENT_TYPE,
             hdrs.CONTENT_ENCODING,
+            # Strips inbound CORS response headers since the aiohttp_cors
+            # library will assert that they are not already present for CORS
+            # requests.
+            hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
+            hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+            hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
         ):
             continue
         headers[name] = value


### PR DESCRIPTION
* Casting the Frigate card results in a HTTP fetch for recordings which is a cors request in that case, which causes the Frigate integration to crash/assert without this PR.