### PR TITLE
Use live_flv option

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -11,7 +11,7 @@ from yarl import URL
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.mqtt import async_publish
-from homeassistant.components.stream import CONF_LIVE_FLV
+from homeassistant.components.stream import CONF_INPUT_FORMAT, FORMAT_LIVE_FLV
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
@@ -109,7 +109,7 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         self._set_motion_topic = (
             f"{frigate_config['mqtt']['topic_prefix']}" f"/{self._cam_name}/motion/set"
         )
-        self.stream_options[CONF_LIVE_FLV] = True
+        self.stream_options[CONF_INPUT_FORMAT] = FORMAT_LIVE_FLV
 
         streaming_template = config_entry.options.get(
             CONF_RTMP_URL_TEMPLATE, ""

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -11,6 +11,7 @@ from yarl import URL
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
 from homeassistant.components.mqtt import async_publish
+from homeassistant.components.stream import CONF_LIVE_FLV
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
@@ -108,6 +109,7 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         self._set_motion_topic = (
             f"{frigate_config['mqtt']['topic_prefix']}" f"/{self._cam_name}/motion/set"
         )
+        self.stream_options[CONF_LIVE_FLV] = True
 
         streaming_template = config_entry.options.get(
             CONF_RTMP_URL_TEMPLATE, ""


### PR DESCRIPTION
Follow up to #283 
Set the live_flv option using the yet to be added CONF_LIVE_FLV field of stream_options. Requires https://github.com/home-assistant/core/pull/73749 to be merged first..
@drthanwho Can you test whether this fixes your issue?