### PR TITLE
Remove the HTTP view for recordings API (WS still available)

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -51,7 +51,6 @@ from .const import (
 from .views import (
     JSMPEGProxyView,
     NotificationsProxyView,
-    RecordingsProxyView,
     SnapshotsProxyView,
     VodProxyView,
     VodSegmentProxyView,
@@ -175,7 +174,6 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     session = async_get_clientsession(hass)
     hass.http.register_view(JSMPEGProxyView(session))
     hass.http.register_view(NotificationsProxyView(session))
-    hass.http.register_view(RecordingsProxyView(session))
     hass.http.register_view(SnapshotsProxyView(session))
     hass.http.register_view(VodProxyView(session))
     hass.http.register_view(VodSegmentProxyView(session))

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -201,20 +201,6 @@ class SnapshotsProxyView(ProxyView):
         return f"api/events/{kwargs['eventid']}/snapshot.jpg"
 
 
-# TODO(@dermotduffy): Remove the RecordingsProxyView after the v4.0.0-rc.2 card release.
-class RecordingsProxyView(ProxyView):
-    """A proxy for recordings."""
-
-    url = "/api/frigate/{frigate_instance_id:.+}/{camera:.+}/recordings{path:.*}"
-    extra_urls = ["/api/frigate/{camera:.+}/recordings{path:.*}"]
-
-    name = "api:frigate:recordings"
-
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"api/{kwargs['camera']}/recordings{kwargs['path']}"
-
-
 class NotificationsProxyView(ProxyView):
     """A proxy for notifications."""
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -149,8 +149,6 @@ async def hass_client_local_frigate(
             web.get("/api/events/event_id/thumbnail.jpg", handler),
             web.get("/api/events/event_id/snapshot.jpg", handler),
             web.get("/api/events/event_id/clip.mp4", handler),
-            web.get("/api/front_door/recordings", qs_handler),
-            web.get("/api/front_door/recordings/summary", handler),
             web.get("/live/front_door", ws_echo_handler),
             web.get("/live/querystring", ws_qs_echo_handler),
         ],
@@ -674,23 +672,3 @@ async def test_ws_proxy_missing_path(
             f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door"
         )
         assert resp.status == HTTPStatus.NOT_FOUND
-
-
-async def test_recordings(
-    hass_client_local_frigate: Any,
-    hass: Any,
-) -> None:
-    """Test recordings."""
-
-    frigate_entries = hass.config_entries.async_entries(DOMAIN)
-    assert frigate_entries
-
-    resp = await hass_client_local_frigate.get(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/front_door/recordings/summary"
-    )
-    assert resp.status == HTTPStatus.OK
-
-    resp = await hass_client_local_frigate.get(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/front_door/recordings?key=value"
-    )
-    assert resp.status == HTTPStatus.OK


### PR DESCRIPTION
* Remove the unnecessary HTTP view for recordings API access. The integration now exposes this API over websocket instead. The only known user of the HTTP view (the card) has already been moved over (in code, not yet build).

Keeping as draft until the card build is released.

**Update**: New card build no-longer relies on recordings over HTTP: https://github.com/dermotduffy/frigate-hass-card/releases/tag/v4.0.0-rc.2