### PR TITLE
Improve devcontainer experience (e.g. adds python debugging, improves port forwarding)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.2
+
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9
+
+# Install Docker
+ENV DOCKER_BUILDKIT="1"
+# https://github.com/microsoft/vscode-dev-containers/commits/main/script-library/docker-debian.sh
+ARG DOCKER_SCRIPT_VERSION="364972b0d7d20ee5de40c1084e65f3f1bc6d5951"
+RUN bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/${DOCKER_SCRIPT_VERSION}/script-library/docker-debian.sh")" \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["/usr/local/share/docker-init.sh"]
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,21 @@
 {
   "dockerComposeFile": "../docker-compose.yml",
   "service": "dev",
-  "workspaceFolder": "/workspace",
+  "workspaceFolder": "${localWorkspaceFolder}",
   "shutdownAction": "stopCompose",
+  "initializeCommand": ".devcontainer/set_dot_env.sh",
   "postCreateCommand": ".devcontainer/post_create.sh",
+  "forwardPorts": ["hass:8123", "frigate:5000"],
+  "portsAttributes": {
+    "hass:8123": {
+      "label": "Home Assistant",
+      "onAutoForward": "silent"
+    },
+    "frigate:5000": {
+      "label": "Frigate",
+      "onAutoForward": "silent"
+    }
+  },
   "extensions": [
     "ms-python.python",
     "visualstudioexptteam.vscodeintellicode",
@@ -14,7 +26,8 @@
     "esbenp.prettier-vscode",
     "ms-python.vscode-pylance",
     "redhat.vscode-yaml",
-    "keesschollaart.vscode-home-assistant"
+    "keesschollaart.vscode-home-assistant",
+    "ms-azuretools.vscode-docker"
   ],
   "settings": {
     "python.defaultInterpreterPath": "/usr/bin/python3",

--- a/.devcontainer/home_assistant_run.sh
+++ b/.devcontainer/home_assistant_run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Start Home Assistant service
+# This file was taken from:
+# https://github.com/home-assistant/core/blob/dd6725b80a5efebda36c64c78250f3374e85c3a7/rootfs/etc/services.d/home-assistant/run
+# And modified to allow starting the Python Debugger.
+# ==============================================================================
+
+# shellcheck shell=bash
+
+cd /config || bashio::exit.nok "Can't find config folder!"
+
+# Enable mimalloc for Home Assistant Core, unless disabled
+if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then
+  export LD_PRELOAD="/usr/local/lib/libjemalloc.so.2"
+  export MALLOC_CONF="background_thread:true,metadata_thp:auto,dirty_decay_ms:20000,muzzy_decay_ms:20000"
+fi
+
+debug_args=()
+if bashio::var.true "${PYTHON_DEBUG:-"false"}"; then
+  debug_args=(-m debugpy --listen 0.0.0.0:5678)
+  bashio::log.info "Enabling Python debug server on port 5678"
+fi
+
+exec python3 "${debug_args[@]}" -m homeassistant --config /config

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -4,6 +4,10 @@ set -euxo pipefail
 
 pip install --disable-pip-version-check --upgrade pip
 
-pip install -r requirements_dev.txt
+pip install pre-commit
 
-pre-commit install --install-hooks
+pip install -r requirements_dev.txt &
+
+pre-commit install --install-hooks &
+
+wait

--- a/.devcontainer/set_dot_env.sh
+++ b/.devcontainer/set_dot_env.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly wanted_line_key="LOCAL_WORKSPACE_FOLDER"
+readonly wanted_line="${wanted_line_key}='${PWD}'"
+readonly file=".env"
+
+echo "Writing ${wanted_line} to ${file}" >&2
+if [[ -f "${file}" ]] && grep --quiet "^${wanted_line_key}=" "${file}"; then
+    sed --in-place "s,^${wanted_line_key}=.*,${wanted_line}," "${file}"
+else
+    echo "${wanted_line}" >>"${file}"
+fi

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,20 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-chrome",
-      "request": "launch",
-      "name": "Launch Chrome against Home Assistant",
-      "url": "http://localhost:48123",
-      "resolveSourceMapLocations": ["!**"]
+      "name": "Python: Attach to Home Assistant",
+      "type": "python",
+      "request": "attach",
+      "connect": { "host": "hass", "port": 5678 },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/custom_components/frigate",
+          "remoteRoot": "/config/custom_components/frigate"
+        }
+      ],
+      "justMyCode": true,
+      "preLaunchTask": "Fetch Home Assistant Logs",
+      // This ensures that the restart button works
+      "postDebugTask": "Restart Home Assistant"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "python.formatting.provider": "black",
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+  "python.formatting.provider": "black",
+  "python.testing.pytestArgs": ["--no-cov", "-p", "no:sugar", "tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Restart Home Assistant",
+      "type": "shell",
+      "command": "docker compose restart hass && sleep 5",
+      "problemMatcher": [],
+      "isBackground": false,
+      "presentation": {
+        "reveal": "silent",
+        "close": true,
+      }
+    },
+    {
+      "label": "Fetch Home Assistant Logs",
+      "type": "shell",
+      "command": "docker compose logs --follow --no-log-prefix hass",
+      "problemMatcher": {
+        "pattern": [
+          {
+            "regexp": ".",
+            "file": 1,
+            "location": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "this line will never be found",
+          "endsPattern": "."
+        }
+      },
+      "isBackground": true,
+      "presentation": {
+        "reveal": "always",
+      }
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,24 @@
 ---
 version: "3"
+
 services:
   dev:
     user: vscode
-    image: mcr.microsoft.com/vscode/devcontainers/python:0-3.9
+    init: true
+    build: .devcontainer
+    env_file:
+      - .env
     volumes:
-      - /etc/localtime:/etc/localtime:ro
-      - .:/workspace:cached
-    command: [sleep, infinity]
+      - /var/run/docker.sock:/var/run/docker-host.sock
+      - .:${LOCAL_WORKSPACE_FOLDER}:cached
   hass:
     image: "homeassistant/home-assistant:${HA_VERSION:-stable}"
     restart: unless-stopped
-    ports:
-      - 48123:8123
+    environment:
+      - PYTHON_DEBUG=true
     volumes:
       - /etc/localtime:/etc/localtime:ro
+      - .devcontainer/home_assistant_run.sh:/etc/services.d/home-assistant/run:ro
       - .devcontainer/preconfig.sh:/etc/cont-init.d/preconfig.sh:ro
       - .devcontainer/preconfig:/preconfig.d/01-integration:ro
       - .devcontainer/config/configuration.yaml:/config/configuration.yaml:ro
@@ -31,11 +35,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - .devcontainer/frigate.yml:/config/config.yml:ro
       - ./frigate:/media/frigate
-    ports:
-      - 45000:5000
-      - 41935:1935
   mqtt:
     image: eclipse-mosquitto:1.6
     restart: unless-stopped
-    ports:
-      - 41883:1883


### PR DESCRIPTION
- Drops the necessity of statically forwarding ports in Remote SSH scenarios (@dermotduffy can you please test this?)
- Drops the necessity of statically set high ports due to possible conflicts for containers (@dermotduffy can you please test this too?), since now port forwarding is handled by VS Code, which will auto-detect the best port to use
- Add docker to devcontainer, as in the Card
  - Refs https://github.com/microsoft/vscode-dev-containers/pull/1522
- Allow Home Assistant to start in debug mode (I hope to merge this in upstream later)
- Add set_dot_env.sh which can be reused later in the Card
- Configure Python debugger which attaches to the Home Assistant process running in the HA container, and everything can be used as expected, like break points and so.
- Drops the post_create.sh duration from 114s to 66s by parallelizing its execution
- Configures PyTest with VS Code, including the option to debug tests
- Makes the Debugger Restart button restart the HA container too
  - Refs https://github.com/keesschollaart81/vscode-home-assistant/issues/2198  
- Stream HA container logs during debug session

Any feedback is welcome.

Demo:

https://user-images.githubusercontent.com/29582865/177250977-39ef4081-eed3-479a-9124-29098165a496.mp4


