### PR TITLE
Add direct link to HACS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Provides the following:
 
 Easiest install is via [HACS](https://hacs.xyz/):
 
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=blakeblackshear&repository=https%3A%2F%2Fgithub.com%2Fblakeblackshear%2Ffrigate-hass-integration&category=camera)
+
 `HACS -> Explore & Add Repositories -> Frigate`
 
 Notes:


### PR DESCRIPTION
This seems to have come out recently: https://my.home-assistant.io/create-link/?redirect=hacs_repository