### PR TITLE
Fetch thumbnails over http instead of using base64 embedded thumbnails

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -52,6 +52,7 @@ from .views import (
     JSMPEGProxyView,
     NotificationsProxyView,
     SnapshotsProxyView,
+    ThumbnailsProxyView,
     VodProxyView,
     VodSegmentProxyView,
 )
@@ -175,6 +176,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     hass.http.register_view(JSMPEGProxyView(session))
     hass.http.register_view(NotificationsProxyView(session))
     hass.http.register_view(SnapshotsProxyView(session))
+    hass.http.register_view(ThumbnailsProxyView(session))
     hass.http.register_view(VodProxyView(session))
     hass.http.register_view(VodSegmentProxyView(session))
     return True

--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -72,6 +72,7 @@ class FrigateApiClient:
             "limit": limit,
             "has_clip": int(has_clip) if has_clip is not None else None,
             "has_snapshot": int(has_snapshot) if has_snapshot is not None else None,
+            "include_thumbnails": 0,
         }
 
         return cast(

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -59,13 +59,7 @@ class FrigateBrowseMediaMetadata:
 
     def __init__(self, event: dict[str, Any]):
         """Initialize a FrigateBrowseMediaMetadata object."""
-        self.event = {
-            # Strip out the thumbnail from the Frigate event, as it is already
-            # included in the BrowseMediaSource.
-            k: event[k]
-            for k in event
-            if k != "thumbnail"
-        }
+        self.event = event
 
     def as_dict(self) -> dict:
         """Convert the object to a dictionary."""

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -869,7 +869,7 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
                     title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{duration}s, {event['label'].capitalize()} {int(event['top_score']*100)}%]",
                     can_play=identifier.media_type == MEDIA_TYPE_VIDEO,
                     can_expand=False,
-                    thumbnail=f"data:image/jpeg;base64,{event['thumbnail']}",
+                    thumbnail=f"/api/static/frigate/{identifier.frigate_instance_id}/thumbnail/{event['id']}",
                     frigate=FrigateBrowseMediaMetadata(event=event),
                 )
             )

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -201,6 +201,19 @@ class SnapshotsProxyView(ProxyView):
         return f"api/events/{kwargs['eventid']}/snapshot.jpg"
 
 
+class ThumbnailsProxyView(ProxyView):
+    """A proxy for snapshots."""
+
+    # Having static in the url will use the CacheFirst() workbox strategy
+    url = "/api/static/frigate/{frigate_instance_id:.+}/thumbnail/{eventid:.*}"
+
+    name = "api:frigate:thumbnails"
+
+    def _create_path(self, **kwargs: Any) -> str | None:
+        """Create path."""
+        return f"api/events/{kwargs['eventid']}/thumbnail.jpg"
+
+
 class NotificationsProxyView(ProxyView):
     """A proxy for notifications."""
 

--- a/tests/fixtures/events_front_door.json
+++ b/tests/fixtures/events_front_door.json
@@ -9,8 +9,7 @@
     "label": "person",
     "start_time": 1623454583.525913,
     "top_score": 0.720703125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -22,8 +21,7 @@
     "label": "person",
     "start_time": 1623426532.275314,
     "top_score": 0.771484375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -35,8 +33,7 @@
     "label": "person",
     "start_time": 1623370502.185623,
     "top_score": 0.75390625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -48,8 +45,7 @@
     "label": "person",
     "start_time": 1623364851.126517,
     "top_score": 0.82421875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -61,8 +57,7 @@
     "label": "person",
     "start_time": 1623364835.320608,
     "top_score": 0.80859375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -74,8 +69,7 @@
     "label": "person",
     "start_time": 1623364821.326626,
     "top_score": 0.84375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -87,8 +81,7 @@
     "label": "person",
     "start_time": 1623362929.841867,
     "top_score": 0.7578125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -100,8 +93,7 @@
     "label": "person",
     "start_time": 1623357709.342476,
     "top_score": 0.8046875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -113,8 +105,7 @@
     "label": "person",
     "start_time": 1623353924.909505,
     "top_score": 0.796875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -126,8 +117,7 @@
     "label": "person",
     "start_time": 1623353024.67293,
     "top_score": 0.8125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -139,8 +129,7 @@
     "label": "person",
     "start_time": 1623348878.990005,
     "top_score": 0.7265625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -152,8 +141,7 @@
     "label": "person",
     "start_time": 1623348870.999845,
     "top_score": 0.751953125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -165,8 +153,7 @@
     "label": "person",
     "start_time": 1623334360.993274,
     "top_score": 0.8203125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -178,8 +165,7 @@
     "label": "person",
     "start_time": 1623278208.495996,
     "top_score": 0.84375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -191,8 +177,7 @@
     "label": "person",
     "start_time": 1623278200.514217,
     "top_score": 0.734375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -204,8 +189,7 @@
     "label": "person",
     "start_time": 1623253177.647162,
     "top_score": 0.71484375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -217,8 +201,7 @@
     "label": "person",
     "start_time": 1623208416.590956,
     "top_score": 0.78515625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -230,8 +213,7 @@
     "label": "person",
     "start_time": 1623208328.59143,
     "top_score": 0.78515625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -243,8 +225,7 @@
     "label": "person",
     "start_time": 1623208222.61608,
     "top_score": 0.82421875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -256,8 +237,7 @@
     "label": "person",
     "start_time": 1623206235.738943,
     "top_score": 0.82421875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -269,8 +249,7 @@
     "label": "person",
     "start_time": 1623206104.010827,
     "top_score": 0.8203125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -282,8 +261,7 @@
     "label": "person",
     "start_time": 1623205957.489517,
     "top_score": 0.79296875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -295,10 +273,7 @@
     "label": "person",
     "start_time": 1623205451.499876,
     "top_score": 0.83203125,
-    "zones": [
-      "bench"
-    ],
-    "thumbnail": "thumbnail"
+    "zones": ["bench"]
   },
   {
     "camera": "front_door",
@@ -310,10 +285,7 @@
     "label": "person",
     "start_time": 1623205285.048291,
     "top_score": 0.82421875,
-    "zones": [
-      "bench"
-    ],
-    "thumbnail": "thumbnail"
+    "zones": ["bench"]
   },
   {
     "camera": "front_door",
@@ -325,10 +297,7 @@
     "label": "person",
     "start_time": 1623205038.04245,
     "top_score": 0.82421875,
-    "zones": [
-      "bench"
-    ],
-    "thumbnail": "thumbnail"
+    "zones": ["bench"]
   },
   {
     "camera": "front_door",
@@ -340,10 +309,7 @@
     "label": "person",
     "start_time": 1623205016.486243,
     "top_score": 0.8046875,
-    "zones": [
-      "bench"
-    ],
-    "thumbnail": "thumbnail"
+    "zones": ["bench"]
   },
   {
     "camera": "front_door",
@@ -355,10 +321,7 @@
     "label": "person",
     "start_time": 1623204877.797351,
     "top_score": 0.82421875,
-    "zones": [
-      "bench"
-    ],
-    "thumbnail": "thumbnail"
+    "zones": ["bench"]
   },
   {
     "camera": "front_door",
@@ -370,8 +333,7 @@
     "label": "person",
     "start_time": 1623203220.771993,
     "top_score": 0.76953125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -383,8 +345,7 @@
     "label": "person",
     "start_time": 1623203179.787299,
     "top_score": 0.796875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -396,8 +357,7 @@
     "label": "person",
     "start_time": 1623202539.9922,
     "top_score": 0.80859375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -409,8 +369,7 @@
     "label": "person",
     "start_time": 1623202383.29624,
     "top_score": 0.78515625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -422,8 +381,7 @@
     "label": "person",
     "start_time": 1623202279.536914,
     "top_score": 0.82421875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -435,8 +393,7 @@
     "label": "person",
     "start_time": 1623200555.723996,
     "top_score": 0.796875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -448,8 +405,7 @@
     "label": "person",
     "start_time": 1623199251.229748,
     "top_score": 0.771484375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -461,8 +417,7 @@
     "label": "person",
     "start_time": 1623199185.284409,
     "top_score": 0.8046875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -474,8 +429,7 @@
     "label": "person",
     "start_time": 1623199164.03415,
     "top_score": 0.796875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -487,8 +441,7 @@
     "label": "person",
     "start_time": 1623199137.784839,
     "top_score": 0.8046875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -500,8 +453,7 @@
     "label": "person",
     "start_time": 1623199098.229762,
     "top_score": 0.8046875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -513,8 +465,7 @@
     "label": "person",
     "start_time": 1623199048.256623,
     "top_score": 0.80859375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -526,8 +477,7 @@
     "label": "person",
     "start_time": 1623199024.772678,
     "top_score": 0.75390625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -539,8 +489,7 @@
     "label": "person",
     "start_time": 1623199003.056419,
     "top_score": 0.75390625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -552,8 +501,7 @@
     "label": "person",
     "start_time": 1623198925.515204,
     "top_score": 0.8046875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -565,8 +513,7 @@
     "label": "person",
     "start_time": 1623198900.24296,
     "top_score": 0.79296875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -578,8 +525,7 @@
     "label": "person",
     "start_time": 1623198859.780307,
     "top_score": 0.8046875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -591,8 +537,7 @@
     "label": "person",
     "start_time": 1623198825.529094,
     "top_score": 0.779296875,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -604,8 +549,7 @@
     "label": "person",
     "start_time": 1623198802.534272,
     "top_score": 0.705078125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -617,8 +561,7 @@
     "label": "person",
     "start_time": 1623198791.523746,
     "top_score": 0.74609375,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -630,8 +573,7 @@
     "label": "person",
     "start_time": 1623198727.993567,
     "top_score": 0.7265625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -643,8 +585,7 @@
     "label": "person",
     "start_time": 1623198711.513559,
     "top_score": 0.76953125,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   },
   {
     "camera": "front_door",
@@ -656,7 +597,6 @@
     "label": "person",
     "start_time": 1623198698.555377,
     "top_score": 0.7265625,
-    "zones": [],
-    "thumbnail": "thumbnail"
+    "zones": []
   }
 ]

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -351,7 +351,7 @@ async def test_async_browse_media_clip_search_drilldown(
         "can_play": True,
         "can_expand": False,
         "children_media_class": None,
-        "thumbnail": "data:image/jpeg;base64,thumbnail",
+        "thumbnail": f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1623454583.525913-y14xk9",
         "title": "2021-06-11 23:36:23 [8s, Person 72%]",
         "frigate": {
             "event": {
@@ -1317,7 +1317,7 @@ async def test_snapshots(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": False,
                 "children_media_class": None,
-                "thumbnail": "data:image/jpeg;base64,thumbnail",
+                "thumbnail": f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1622764801.555377-55xy6j",
                 "frigate": {
                     "event": {
                         "camera": "front_door",
@@ -1435,7 +1435,7 @@ async def test_in_progress_event(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": False,
                 "children_media_class": None,
-                "thumbnail": "data:image/jpeg;base64,thumbnail",
+                "thumbnail": f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1622764820.555377-55xy6j",
                 "frigate": {
                     "event": {
                         "camera": "front_door",

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -1277,7 +1277,6 @@ async def test_snapshots(hass: HomeAssistant) -> None:
                 "start_time": 1622764801,
                 "top_score": 0.7265625,
                 "zones": [],
-                "thumbnail": "thumbnail",
             }
         ]
     )
@@ -1392,7 +1391,6 @@ async def test_in_progress_event(hass: HomeAssistant) -> None:
                 "start_time": 1622764820.0,
                 "top_score": 0.7265625,
                 "zones": [],
-                "thumbnail": "thumbnail",
             }
         ]
     )
@@ -1472,7 +1470,6 @@ async def test_bad_event(hass: HomeAssistant) -> None:
                 "label": "person",
                 "top_score": 0.7265625,
                 "zones": [],
-                "thumbnail": "thumbnail",
             }
         ]
     )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -378,6 +378,28 @@ async def test_snapshots_with_frigate_instance_id(
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
+async def test_thumbnails_with_frigate_instance_id(
+    hass_client_local_frigate: Any,
+    hass: Any,
+) -> None:
+    """Test snapshot with config entry ids."""
+
+    frigate_entries = hass.config_entries.async_entries(DOMAIN)
+    assert frigate_entries
+
+    # A Frigate instance id is specified.
+    resp = await hass_client_local_frigate.get(
+        f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/event_id"
+    )
+    assert resp.status == HTTPStatus.OK
+
+    # An invalid instance id is specified.
+    resp = await hass_client_local_frigate.get(
+        "/api/static/frigate/NOT_A_REAL_ID/thumbnail/event_id"
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
+
+
 async def test_vod_with_frigate_instance_id(
     hass_client_local_frigate: Any,
     hass: Any,


### PR DESCRIPTION
:boom: Frigate card users will require the latest card build to continue to have working thumbnails.

@blakeblackshear This is an alternative implementation which uses http for the thumbnails instead of getting them upfront and sending them in the BrowseMediaSource.
The downside of this is that it doesn't fetch the images upfront, so there's going to be more latency.
With small thumbnails, this is probably a worse solution, but if there's a move to larger/more thumbnails this might be better.

Note - this does seem to raise a problem with HA's ip ban middleware. I'll try to put a fix in for that over there.