### PR TITLE
Use iter_any() instead of iter_chunked()

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -176,7 +176,7 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
 
             try:
                 await response.prepare(request)
-                async for data in result.content.iter_chunked(4096):
+                async for data in result.content.iter_any():
                     await response.write(data)
 
             except (aiohttp.ClientError, aiohttp.ClientPayloadError) as err:


### PR DESCRIPTION
iter_any() seems better to use as it allows us to send out whatever we have so far instead of looping through each chunk. I do not have a good setup to test this though (I use H.265 so don't actually use Frigate much).