### PR TITLE
Remove "static/" from ThumbnailsProxyView path

### DIFF
--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -17,7 +17,6 @@ from homeassistant.components.media_player.const import (
     MEDIA_TYPE_IMAGE,
     MEDIA_TYPE_VIDEO,
 )
-from homeassistant.components.media_source.const import MEDIA_MIME_TYPES
 from homeassistant.components.media_source.error import MediaSourceError, Unresolvable
 from homeassistant.components.media_source.models import (
     BrowseMediaSource,
@@ -597,7 +596,8 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
         raise Unresolvable("Unknown or disallowed identifier: %s" % item.identifier)
 
     async def async_browse_media(
-        self, item: MediaSourceItem, media_types: tuple[str] = MEDIA_MIME_TYPES
+        self,
+        item: MediaSourceItem,
     ) -> BrowseMediaSource:
         """Browse media."""
 
@@ -863,7 +863,7 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
                     title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{duration}s, {event['label'].capitalize()} {int(event['top_score']*100)}%]",
                     can_play=identifier.media_type == MEDIA_TYPE_VIDEO,
                     can_expand=False,
-                    thumbnail=f"/api/static/frigate/{identifier.frigate_instance_id}/thumbnail/{event['id']}",
+                    thumbnail=f"/api/frigate/{identifier.frigate_instance_id}/thumbnail/{event['id']}",
                     frigate=FrigateBrowseMediaMetadata(event=event),
                 )
             )

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -204,8 +204,7 @@ class SnapshotsProxyView(ProxyView):
 class ThumbnailsProxyView(ProxyView):
     """A proxy for snapshots."""
 
-    # Having static in the url will use the CacheFirst() workbox strategy
-    url = "/api/static/frigate/{frigate_instance_id:.+}/thumbnail/{eventid:.*}"
+    url = "/api/frigate/{frigate_instance_id:.+}/thumbnail/{eventid:.*}"
 
     name = "api:frigate:thumbnails"
 

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -351,7 +351,7 @@ async def test_async_browse_media_clip_search_drilldown(
         "can_play": True,
         "can_expand": False,
         "children_media_class": None,
-        "thumbnail": f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1623454583.525913-y14xk9",
+        "thumbnail": f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1623454583.525913-y14xk9",
         "title": "2021-06-11 23:36:23 [8s, Person 72%]",
         "frigate": {
             "event": {
@@ -1316,7 +1316,7 @@ async def test_snapshots(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": False,
                 "children_media_class": None,
-                "thumbnail": f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1622764801.555377-55xy6j",
+                "thumbnail": f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1622764801.555377-55xy6j",
                 "frigate": {
                     "event": {
                         "camera": "front_door",
@@ -1433,7 +1433,7 @@ async def test_in_progress_event(hass: HomeAssistant) -> None:
                 "can_play": False,
                 "can_expand": False,
                 "children_media_class": None,
-                "thumbnail": f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1622764820.555377-55xy6j",
+                "thumbnail": f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/1622764820.555377-55xy6j",
                 "frigate": {
                     "event": {
                         "camera": "front_door",

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -389,13 +389,13 @@ async def test_thumbnails_with_frigate_instance_id(
 
     # A Frigate instance id is specified.
     resp = await hass_client_local_frigate.get(
-        f"/api/static/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/event_id"
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/thumbnail/event_id"
     )
     assert resp.status == HTTPStatus.OK
 
     # An invalid instance id is specified.
     resp = await hass_client_local_frigate.get(
-        "/api/static/frigate/NOT_A_REAL_ID/thumbnail/event_id"
+        "/api/frigate/NOT_A_REAL_ID/thumbnail/event_id"
     )
     assert resp.status == HTTPStatus.BAD_REQUEST
 


### PR DESCRIPTION
Chromium's service worker cache [exhibits poor performance](https://bugs.chromium.org/p/chromium/issues/detail?id=682677) when using ignoreSearch:true (which is necessary for paths using HA's auth). This makes it unsuitable for thumbnails especially as they are 1) numerous (the latency appears to increase linearly with number of cached objects) and 2) small (there's not much data usage savings, so latency would have been the main benefit, but even that doesn't appear to be a benefit here).
This PR removes "static" from the ThumbnailsProxyView path name. The service worker should now treat it with the NetworkOnly() strategy.