### PR TITLE
Restore JSON decode for ws_api

### DIFF
--- a/custom_components/frigate/ws_api.py
+++ b/custom_components/frigate/ws_api.py
@@ -59,9 +59,7 @@ async def ws_retain_event(
     try:
         connection.send_result(
             msg["id"],
-            await client.async_retain(
-                msg["event_id"], msg["retain"], decode_json=False
-            ),
+            await client.async_retain(msg["event_id"], msg["retain"]),
         )
     except FrigateApiClientError:
         connection.send_error(
@@ -95,7 +93,7 @@ async def ws_get_recordings(
         connection.send_result(
             msg["id"],
             await client.async_get_recordings(
-                msg["camera"], msg.get("after"), msg.get("before"), decode_json=False
+                msg["camera"], msg.get("after"), msg.get("before")
             ),
         )
     except FrigateApiClientError:
@@ -127,7 +125,7 @@ async def ws_get_recordings_summary(
     try:
         connection.send_result(
             msg["id"],
-            await client.async_get_recordings_summary(msg["camera"], decode_json=False),
+            await client.async_get_recordings_summary(msg["camera"]),
         )
     except FrigateApiClientError:
         connection.send_error(

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -40,7 +40,7 @@ async def test_retain_success(hass: HomeAssistant, hass_ws_client: Any) -> None:
     await ws_client.send_json(retain_json)
 
     response = await ws_client.receive_json()
-    mock_client.async_retain.assert_called_with(TEST_EVENT_ID, True, decode_json=False)
+    mock_client.async_retain.assert_called_with(TEST_EVENT_ID, True)
     assert response["success"]
     assert response["result"] == retain_success
 
@@ -55,7 +55,7 @@ async def test_retain_success(hass: HomeAssistant, hass_ws_client: Any) -> None:
     )
 
     response = await ws_client.receive_json()
-    mock_client.async_retain.assert_called_with(TEST_EVENT_ID, False, decode_json=False)
+    mock_client.async_retain.assert_called_with(TEST_EVENT_ID, False)
     assert response["success"]
     assert response["result"] == unretain_success
 
@@ -141,9 +141,7 @@ async def test_get_recordings_success(hass: HomeAssistant, hass_ws_client: Any) 
     await ws_client.send_json(recording_json)
 
     response = await ws_client.receive_json()
-    mock_client.async_get_recordings_summary.assert_called_with(
-        TEST_CAMERA, decode_json=False
-    )
+    mock_client.async_get_recordings_summary.assert_called_with(TEST_CAMERA)
     assert response["success"]
     assert response["result"] == recording_success
 
@@ -162,9 +160,7 @@ async def test_get_recordings_success(hass: HomeAssistant, hass_ws_client: Any) 
     )
 
     response = await ws_client.receive_json()
-    mock_client.async_get_recordings.assert_called_with(
-        TEST_CAMERA, after, before, decode_json=False
-    )
+    mock_client.async_get_recordings.assert_called_with(TEST_CAMERA, after, before)
     assert response["success"]
     assert response["result"] == recording_success
 


### PR DESCRIPTION
* Was breaking the card which was just receiving the raw string: https://github.com/dermotduffy/frigate-hass-card/issues/790
* Makes sense to decode this on the HA side and the ws_api caller just receives the decoded data.
* Related: https://github.com/blakeblackshear/frigate-hass-integration/pull/321