### PR TITLE
Don't proxy authSig parameter unless necessary

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -164,7 +164,11 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
             request.method,
             url,
             headers=source_header,
-            params=request.query,
+            params={
+                k: v
+                for k, v in request.query.items()
+                if k != "authSig" or isinstance(self, VodProxyView)
+            },
             allow_redirects=False,
             data=data,
         ) as result:

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from http import HTTPStatus
 from ipaddress import ip_address
 import logging
@@ -138,6 +139,11 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
 
         raise HTTPBadGateway() from None
 
+    @staticmethod
+    def _get_query_params(request: web.Request) -> Mapping[str, str]:
+        """Get the query params to send upstream."""
+        return {k: v for k, v in request.query.items() if k != "authSig"}
+
     async def _handle_request(
         self,
         request: web.Request,
@@ -164,11 +170,7 @@ class ProxyView(HomeAssistantView):  # type: ignore[misc]
             request.method,
             url,
             headers=source_header,
-            params={
-                k: v
-                for k, v in request.query.items()
-                if k != "authSig" or isinstance(self, VodProxyView)
-            },
+            params=self._get_query_params(request),
             allow_redirects=False,
             data=data,
         ) as result:
@@ -250,7 +252,12 @@ class VodProxyView(ProxyView):
     url = "/api/frigate/{frigate_instance_id:.+}/vod/{path:.+}/{manifest:.+}.m3u8"
     extra_urls = ["/api/frigate/vod/{path:.+}/{manifest:.+}.m3u8"]
 
-    name = "api:frigate:vod:mainfest"
+    name = "api:frigate:vod:manifest"
+
+    @staticmethod
+    def _get_query_params(request: web.Request) -> Mapping[str, str]:
+        """Get the query params to send upstream."""
+        return request.query
 
     def _create_path(self, **kwargs: Any) -> str | None:
         """Create path."""


### PR DESCRIPTION
Passing the authSig in the query parameters is unnecessary and may prevent cache from working properly. Passing the authSig is only required for VodProxyView (so that the HLS manifests that get sent back have segment URLs that include the authSig).