### PR TITLE
Change Frigate `api` and `ws_api` to multi selection instead of single selection

### DIFF
--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -53,9 +53,9 @@ class FrigateApiClient:
 
     async def async_get_events(
         self,
-        camera: str | None = None,
-        label: str | None = None,
-        zone: str | None = None,
+        cameras: list[str] | None = None,
+        labels: list[str] | None = None,
+        zones: list[str] | None = None,
         after: int | None = None,
         before: int | None = None,
         limit: int | None = None,
@@ -65,9 +65,9 @@ class FrigateApiClient:
     ) -> list[dict[str, Any]]:
         """Get data from the API."""
         params = {
-            "camera": camera,
-            "label": label,
-            "zone": zone,
+            "cameras": ",".join(cameras) if cameras else None,
+            "labels": ",".join(labels) if labels else None,
+            "zones": ",".join(zones) if zones else None,
             "after": after,
             "before": before,
             "limit": limit,

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -685,9 +685,9 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
                 events = await self._get_client(identifier).async_get_events(
                     after=identifier.after,
                     before=identifier.before,
-                    camera=identifier.camera,
-                    label=identifier.label,
-                    zone=identifier.zone,
+                    cameras=[identifier.camera] if identifier.camera else None,
+                    labels=[identifier.label] if identifier.label else None,
+                    zones=[identifier.zone] if identifier.zone else None,
                     limit=10000 if identifier.name.endswith(".all") else ITEM_LIMIT,
                     **media_kwargs,
                 )

--- a/custom_components/frigate/ws_api.py
+++ b/custom_components/frigate/ws_api.py
@@ -147,9 +147,9 @@ async def ws_get_recordings_summary(
     {
         vol.Required("type"): "frigate/events/get",
         vol.Required("instance_id"): str,
-        vol.Optional("camera"): str,
-        vol.Optional("label"): str,
-        vol.Optional("zone"): str,
+        vol.Optional("cameras"): [str],
+        vol.Optional("labels"): [str],
+        vol.Optional("zones"): [str],
         vol.Optional("after"): int,
         vol.Optional("before"): int,
         vol.Optional("limit"): int,
@@ -172,9 +172,9 @@ async def ws_get_events(
         connection.send_result(
             msg["id"],
             await client.async_get_events(
-                msg.get("camera"),
-                msg.get("label"),
-                msg.get("zone"),
+                msg.get("cameras"),
+                msg.get("labels"),
+                msg.get("zones"),
                 msg.get("after"),
                 msg.get("before"),
                 msg.get("limit"),
@@ -187,8 +187,8 @@ async def ws_get_events(
         connection.send_error(
             msg["id"],
             "frigate_error",
-            f"API error whilst retrieving events for camera "
-            f"{msg['camera']} for Frigate instance {msg['instance_id']}",
+            f"API error whilst retrieving events for cameras "
+            f"{msg['cameras']} for Frigate instance {msg['instance_id']}",
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,9 +79,9 @@ async def test_async_get_events(
         _assert_request_params(
             request,
             {
-                "camera": "test_camera",
-                "label": "test_label",
-                "zone": "test_zone",
+                "cameras": "test_camera1,test_camera2",
+                "labels": "test_label1,test_label2",
+                "zones": "test_zone1,test_zone2",
                 "after": "1",
                 "before": "2",
                 "limit": "3",
@@ -96,9 +96,9 @@ async def test_async_get_events(
 
     frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
     assert events_in == await frigate_client.async_get_events(
-        camera="test_camera",
-        label="test_label",
-        zone="test_zone",
+        cameras=["test_camera1", "test_camera2"],
+        labels=["test_label1", "test_label2"],
+        zones=["test_zone1", "test_zone2"],
         after=1,
         before=2,
         limit=3,

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -1253,9 +1253,9 @@ async def test_snapshots(hass: HomeAssistant) -> None:
     assert client.async_get_events.call_args == call(
         after=1622764800,
         before=1622851200,
-        camera="front_door",
-        label="person",
-        zone=None,
+        cameras=["front_door"],
+        labels=["person"],
+        zones=None,
         limit=50,
         has_snapshot=True,
     )

--- a/tests/test_ws_api.py
+++ b/tests/test_ws_api.py
@@ -253,9 +253,9 @@ async def test_get_events_success(hass: HomeAssistant, hass_ws_client: Any) -> N
         "id": 1,
         "type": "frigate/events/get",
         "instance_id": TEST_FRIGATE_INSTANCE_ID,
-        "camera": TEST_CAMERA,
-        "label": TEST_LABEL,
-        "zone": TEST_ZONE,
+        "cameras": [TEST_CAMERA],
+        "labels": [TEST_LABEL],
+        "zones": [TEST_ZONE],
         "after": 1,
         "before": 2,
         "limit": 3,
@@ -269,7 +269,7 @@ async def test_get_events_success(hass: HomeAssistant, hass_ws_client: Any) -> N
 
     response = await ws_client.receive_json()
     mock_client.async_get_events.assert_called_with(
-        TEST_CAMERA, TEST_LABEL, TEST_ZONE, 1, 2, 3, True, True, decode_json=False
+        [TEST_CAMERA], [TEST_LABEL], [TEST_ZONE], 1, 2, 3, True, True, decode_json=False
     )
     assert response["success"]
     assert response["result"] == events_success
@@ -287,7 +287,7 @@ async def test_get_events_instance_not_found(
         "id": 1,
         "type": "frigate/events/get",
         "instance_id": "THIS-IS-NOT-A-REAL-INSTANCE-ID",
-        "camera": TEST_CAMERA,
+        "cameras": [TEST_CAMERA],
     }
 
     await ws_client.send_json(events_json)
@@ -307,7 +307,7 @@ async def test_get_events_api_error(hass: HomeAssistant, hass_ws_client: Any) ->
         "id": 1,
         "type": "frigate/events/get",
         "instance_id": TEST_FRIGATE_INSTANCE_ID,
-        "camera": TEST_CAMERA,
+        "cameras": [TEST_CAMERA],
     }
 
     mock_client.async_get_events = AsyncMock(side_effect=FrigateApiClientError)


### PR DESCRIPTION
 * Helps reduce number of calls to the backend.
 * Integration itself should work seamlessly.
 * This is a breaking change for any (unknown) external users of these APIs.