### PR TITLE
Latest version check: add handling for "disabled"

### DIFF
--- a/custom_components/frigate/update.py
+++ b/custom_components/frigate/update.py
@@ -85,7 +85,7 @@ class FrigateContainerUpdate(FrigateEntity, UpdateEntity, CoordinatorEntity):  #
 
         version = self.coordinator.data.get("service", {}).get("latest_version")
 
-        if not version or version == "unknown":
+        if not version or version == "unknown" or version == "disabled":
             return None
 
         return str(version)


### PR DESCRIPTION
This goes alongside https://github.com/blakeblackshear/frigate/pull/5208 to ensure that the HASS integration correctly handles the new "disabled" API response that occurs if the Frigate version update check is disabled.