### PR TITLE
Revert "Force AAC audio to be used in RTSP URL (#419)"

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -167,8 +167,9 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
                     **self._camera_config
                 )
             else:
-                # TODO: Remover after https://github.com/AlexxIT/go2rtc/issues/194 gets fixed
-                self._stream_source = f"rtsp://{URL(self._url).host}:8554/{self._cam_name}?video=copy&audio=aac"
+                self._stream_source = (
+                    f"rtsp://{URL(self._url).host}:8554/{self._cam_name}"
+                )
 
         elif self._camera_config.get("rtmp", {}).get("enabled"):
             self._restream_type = "rtmp"

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -61,7 +61,7 @@ async def test_frigate_camera_setup_rtsp(
 
     source = await async_get_stream_source(hass, TEST_CAMERA_FRONT_DOOR_ENTITY_ID)
     assert source
-    assert source == "rtsp://example.com:8554/front_door?video=copy&audio=aac"
+    assert source == "rtsp://example.com:8554/front_door"
 
     aioclient_mock.get(
         "http://example.com/api/front_door/latest.jpg?h=277",


### PR DESCRIPTION
- This reverts commit b91d882a96b1fa4a45a4d7e9bb9329392e41fad6, which is no longer necessary since https://github.com/AlexxIT/go2rtc/issues/194 was fixed.

- Refs https://github.com/blakeblackshear/frigate-hass-integration/issues/418