### PR TITLE
Add `go2rtc_stream_name` attribute for cameras (for WebRTC integration)

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -136,11 +136,14 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         # The device_class is used to filter out regular camera entities
         # from motion camera entities on selectors
         self._attr_device_class = DEVICE_CLASS_CAMERA
-        self._attr_is_streaming = (
-            self._camera_config.get("rtmp", {}).get("enabled")
-            or self._cam_name
+        if (
+            self._cam_name
             in self._frigate_config.get("go2rtc", {}).get("streams", {}).keys()
-        )
+        ):
+            self._attr_is_streaming = True
+            self._attr_go2rtc_stream_name = self._cam_name
+        elif self._camera_config.get("rtmp", {}).get("enabled"):
+            self._attr_is_streaming = True
         self._attr_is_recording = self._camera_config.get("record", {}).get("enabled")
         self._attr_motion_detection_enabled = self._camera_config.get("motion", {}).get(
             "enabled"

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -136,13 +136,11 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         # The device_class is used to filter out regular camera entities
         # from motion camera entities on selectors
         self._attr_device_class = DEVICE_CLASS_CAMERA
-        if (
-            self._cam_name
+        self._attr_is_streaming = (
+            self._camera_config.get("rtmp", {}).get("enabled")
+            or self._cam_name
             in self._frigate_config.get("go2rtc", {}).get("streams", {}).keys()
-        ):
-            self._attr_is_streaming = True
-        elif self._camera_config.get("rtmp", {}).get("enabled"):
-            self._attr_is_streaming = True
+        )
         self._attr_is_recording = self._camera_config.get("record", {}).get("enabled")
         self._attr_motion_detection_enabled = self._camera_config.get("motion", {}).get(
             "enabled"

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -141,7 +141,6 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
             in self._frigate_config.get("go2rtc", {}).get("streams", {}).keys()
         ):
             self._attr_is_streaming = True
-            self._attr_go2rtc_stream_name = self._cam_name
         elif self._camera_config.get("rtmp", {}).get("enabled"):
             self._attr_is_streaming = True
         self._attr_is_recording = self._camera_config.get("record", {}).get("enabled")
@@ -232,9 +231,12 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
     @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return entity specific state attributes."""
-        return {
+        result = {
             "restream_type": self._restream_type,
         }
+        if self._restream_type == "rtsp":
+            result["go2rtc_stream_name"] = self._cam_name
+        return result
 
     @property
     def supported_features(self) -> int:
@@ -350,6 +352,13 @@ class BirdseyeCamera(FrigateEntity, Camera):  # type: ignore[misc]
             "model": self._get_model(),
             "configuration_url": f"{self._url}/cameras/birdseye",
             "manufacturer": NAME,
+        }
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return entity specific state attributes."""
+        return {
+            "go2rtc_stream_name": "birdseye",
         }
 
     @property

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -58,6 +58,7 @@ async def test_frigate_camera_setup_rtsp(
     assert entity_state.state == "streaming"
     assert entity_state.attributes["supported_features"] == 2
     assert entity_state.attributes["restream_type"] == "rtsp"
+    assert entity_state.attributes["go2rtc_stream_name"] == "front_door"
 
     source = await async_get_stream_source(hass, TEST_CAMERA_FRONT_DOOR_ENTITY_ID)
     assert source

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -86,6 +86,7 @@ async def test_frigate_camera_setup_birdseye_rtsp(hass: HomeAssistant) -> None:
     entity_state = hass.states.get(TEST_CAMERA_BIRDSEYE_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "streaming"
+    assert entity_state.attributes["go2rtc_stream_name"] == "birdseye"
 
     source = await async_get_stream_source(hass, TEST_CAMERA_BIRDSEYE_ENTITY_ID)
     assert source


### PR DESCRIPTION
So that the WebRTC Camera integration can take the camera as an entity rather than the url, which can be confusing for users.

@alexxit, do you think this is something that your WebRTC integration can add support for?
