### PR TITLE
Ignore attribute labels

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -37,6 +37,7 @@ from .const import (
     ATTR_CLIENT,
     ATTR_CONFIG,
     ATTR_COORDINATOR,
+    ATTRIBUTE_LABELS,
     CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     DOMAIN,
     FRIGATE_RELEASES_URL,
@@ -103,7 +104,8 @@ def get_cameras_and_objects(
     camera_objects = set()
     for cam_name, cam_config in config["cameras"].items():
         for obj in cam_config["objects"]["track"]:
-            camera_objects.add((cam_name, obj))
+            if obj not in ATTRIBUTE_LABELS:
+                camera_objects.add((cam_name, obj))
 
         # add an artificial all label to track
         # all objects for this camera

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -34,6 +34,8 @@ ATTR_FAVORITE = "favorite"
 ATTR_MQTT = "mqtt"
 
 # Frigate Attribute Labels
+# These are labels that are not individually tracked as they are
+# attributes of another label. ex: face is an attribute of person
 ATTRIBUTE_LABELS = ["amazon", "face", "fedex", "license_plate", "ups"]
 
 # Configuration and options

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -33,6 +33,9 @@ ATTR_EVENT_ID = "event_id"
 ATTR_FAVORITE = "favorite"
 ATTR_MQTT = "mqtt"
 
+# Frigate Attribute Labels
+ATTRIBUTE_LABELS = ["amazon", "face", "fedex", "license_plate", "ups"]
+
 # Configuration and options
 CONF_CAMERA_STATIC_IMAGE_HEIGHT = "camera_image_height"
 CONF_MEDIA_BROWSER_ENABLE = "media_browser_enable"


### PR DESCRIPTION
In Frigate 0.13 along with Frigate+ there are certain labels (amazon, face, license_plate, etc.) which are not separately tracked objects and are ONLY attributes of another label (a person has a face, a car has a license plate, etc.)

Given that these labels are not treated as other objects, they will not have their own MQTT snapshots, object counts, etc. so they should be filtered out from the objects that are added.