### PR TITLE
Ignore processes

### DIFF
--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -48,6 +48,9 @@ async def async_setup_entry(
         elif key == "gpu_usages":
             for name in value.keys():
                 entities.append(GpuLoadSensor(coordinator, entry, name))
+        elif key == "processes":
+            # don't create sensor for other processes
+            continue
         elif key == "service":
             # Temperature is only supported on PCIe Coral.
             for name in value.get("temperatures", {}):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -221,6 +221,12 @@ TEST_STATS = {
             "mem": "57.0 %",
         }
     },
+    "processes": {
+        "audioDetector": { "pid": 835 },
+        "go2rtc": { "pid": 89 },
+        "logger": { "pid": 727 },
+        "recording": { "pid": 729 },
+    }
 }
 TEST_EVENT_SUMMARY = [
     # Today

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -222,11 +222,11 @@ TEST_STATS = {
         }
     },
     "processes": {
-        "audioDetector": { "pid": 835 },
-        "go2rtc": { "pid": 89 },
-        "logger": { "pid": 727 },
-        "recording": { "pid": 729 },
-    }
+        "audioDetector": {"pid": 835},
+        "go2rtc": {"pid": 89},
+        "logger": {"pid": 727},
+        "recording": {"pid": 729},
+    },
 }
 TEST_EVENT_SUMMARY = [
     # Today


### PR DESCRIPTION
Frigate 0.13 has added a new processes type for stats info on other processes. I don't think these make sense to be added into HA integration, so ignoring the key