### PR TITLE
Set version to v5.0.0-beta.1

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -14,5 +14,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "requirements": ["pytz==2022.7"],
-    "version": "5.0.0-beta1"
+    "version": "5.0.0-beta.1"
 }

--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -14,5 +14,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "requirements": ["pytz==2022.7"],
-    "version": "4.0.0"
+    "version": "5.0.0-beta1"
 }


### PR DESCRIPTION
There are no more new changes coming in for the frigate integration before frigate 0.13 beta, so creating the PR to bump the version. Not sure if it makes sense to leave in the dev branch until it makes it to stable or if the release process requires merging dev to master.