### PR TITLE
Update build to `5.0.0-beta.3`

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -14,5 +14,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "requirements": ["pytz==2022.7"],
-    "version": "5.0.0-beta.2"
+    "version": "5.0.0-beta.3"
 }


### PR DESCRIPTION
Will be paired with upcoming frigate 0.13 beta 3, which should be ready in a day or two time. I believe this can be merged now and a release done in sync with the 0.13 beta 3 release