### PR TITLE
Fix to allow basic auth in frigate-hass-card thumbnails

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -524,6 +524,7 @@ def _init_header(request: web.Request) -> CIMultiDict | dict[str, str]:
             hdrs.SEC_WEBSOCKET_VERSION,
             hdrs.SEC_WEBSOCKET_KEY,
             hdrs.HOST,
+            hdrs.AUTHORIZATION,
         ):
             continue
         headers[name] = value


### PR DESCRIPTION
I setup basic auth in front of frigate with caddy and this is the only issue I have had. 
The thumbnail previews were broken in frigate-hass-card and
I was getting errors in home assistant logs "ValueError: Cannot combine AUTHORIZATION header with AUTH argument or credentials encoded in URL" I am passing basic auth in the url.

Removing the passed through AUTHORIZATION header, which I assume is for home assistant authorization and not needed for api calls on to frigate.... Fixed the issue.