### PR TITLE
Fix camera supported_features to return CameraEntityFeature

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -235,12 +235,12 @@ class FrigateCamera(FrigateMQTTEntity, Camera):  # type: ignore[misc]
         }
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> CameraEntityFeature:
         """Return supported features of this camera."""
         if not self._attr_is_streaming:
-            return 0
+            return CameraEntityFeature(0)
 
-        return cast(int, CameraEntityFeature.STREAM)
+        return CameraEntityFeature.STREAM
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
@@ -351,9 +351,9 @@ class BirdseyeCamera(FrigateEntity, Camera):  # type: ignore[misc]
         }
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> CameraEntityFeature:
         """Return supported features of this camera."""
-        return cast(int, CameraEntityFeature.STREAM)
+        return CameraEntityFeature.STREAM
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation
https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/
related issue https://github.com/home-assistant/core/issues/106522