### PR TITLE
Allow HLS fallback in webrtc mode

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -197,22 +197,23 @@ class FrigateCamera(FrigateMQTTEntity, CoordinatorEntity, Camera):  # type: igno
             else:
                 self._restream_type = "rtsp"
                 self._attr_frontend_stream_type = StreamType.HLS
-                streaming_template = config_entry.options.get(
-                    CONF_RTSP_URL_TEMPLATE, ""
-                ).strip()
 
-                if streaming_template:
-                    # Can't use homeassistant.helpers.template as it requires hass which
-                    # is not available in the constructor, so use direct jinja2
-                    # template instead. This means templates cannot access HomeAssistant
-                    # state, but rather only the camera config.
-                    self._stream_source = Template(streaming_template).render(
-                        **self._camera_config
-                    )
-                else:
-                    self._stream_source = (
-                        f"rtsp://{URL(self._url).host}:8554/{self._cam_name}"
-                    )
+            streaming_template = config_entry.options.get(
+                CONF_RTSP_URL_TEMPLATE, ""
+            ).strip()
+
+            if streaming_template:
+                # Can't use homeassistant.helpers.template as it requires hass which
+                # is not available in the constructor, so use direct jinja2
+                # template instead. This means templates cannot access HomeAssistant
+                # state, but rather only the camera config.
+                self._stream_source = Template(streaming_template).render(
+                    **self._camera_config
+                )
+            else:
+                self._stream_source = (
+                    f"rtsp://{URL(self._url).host}:8554/{self._cam_name}"
+                )
         elif self._camera_config.get("rtmp", {}).get("enabled"):
             self._restream_type = "rtmp"
             streaming_template = config_entry.options.get(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -117,7 +117,7 @@ async def test_frigate_camera_setup_web_rtc(
     assert entity_state.attributes["frontend_stream_type"] == StreamType.WEB_RTC
 
     source = await async_get_stream_source(hass, TEST_CAMERA_FRONT_DOOR_ENTITY_ID)
-    assert source is None
+    assert source == "rtsp://example.com:8554/front_door"
 
     aioclient_mock.post(
         "http://example.com/api/go2rtc/webrtc?src=front_door",


### PR DESCRIPTION
Allow cameras to provide an HLS even if they're set up as WebRTC so they can work as a media source.