### PR TITLE
Fix media browsing bug with events where `top_score` is `0`

### DIFF
--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -857,7 +857,7 @@ class FrigateMediaSource(MediaSource):  # type: ignore[misc]
                     ),
                     media_class=identifier.media_class,
                     media_content_type=identifier.media_type,
-                    title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{duration}s, {event['label'].capitalize()} {int((event['data'].get('top_score') or event['top_score'])*100)}%]",
+                    title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{duration}s, {event['label'].capitalize()} {int((event['data'].get('top_score') or event['top_score'] or 0)*100)}%]",
                     can_play=identifier.media_type == MEDIA_TYPE_VIDEO,
                     can_expand=False,
                     thumbnail=f"/api/frigate/{identifier.frigate_instance_id}/thumbnail/{event['id']}",


### PR DESCRIPTION
Fix a bug where home assistant media browser fails to load clips if any have a `top_score` of zero.

The errors look like this:

```
  File "/config/custom_components/frigate/media_source.py", line 774, in _browse_events
    event_items = self._build_event_response(identifier, events)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/frigate/media_source.py", line 860, in _build_event_response
    title=f"{dt.datetime.fromtimestamp(event['start_time'], DEFAULT_TIME_ZONE).strftime(DATE_STR_FORMAT)} [{duration}s, {event['label'].capitalize()} {int((event['data'].get('top_score') or event['top_score'])*100)}%]",
                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

This was mostly fixed in [this commit](https://github.com/blakeblackshear/frigate-hass-integration/commit/0fe132f42ba91f799456ee4539970e6f338afdec), but python evaluates `(0 or None)` as `None` (interestingly, it evaluates `(None or 0)` as `0`). This means that if `event['top_score']` is `0` (which can happen if you create the event through an API call, for instance... that's how I found this bug) and `event['data'].get('top_score')` is `None`, the expression evaluates to `int(None * 100)`, which causes the error.

This fixes it by adding a default case of 0.


My event that triggered this bug, as reported by `/api/events?limit=50&has_clip=1&include_thumbnails=0`:

```
...
  {
    "box": null,
    "camera": "doorbell",
    "data": {
      "score": 0,
      "top_score": 0,
      "type": "api"
    },
    "end_time": 1707375125.15415,
    "false_positive": null,
    "has_clip": true,
    "has_snapshot": true,
    "id": "1707375090.154146-rfnk4j",
    "label": "testevent",
    "plus_id": null,
    "retain_indefinitely": false,
    "start_time": 1707375085.15415,
    "sub_label": null,
    "top_score": null,
    "zones": []
  },
...
```