### PR TITLE
Unpin pytz version in manifest requirement

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -13,6 +13,6 @@
     "documentation": "https://github.com/blakeblackshear/frigate",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
-    "requirements": ["pytz==2022.7"],
+    "requirements": ["pytz"],
     "version": "5.0.1"
 }


### PR DESCRIPTION
Rely on the pytz version included with Home Assistant

closes #634 