### PR TITLE
Fix import of Config for HA 2024.11.0b0

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -26,7 +26,8 @@ from homeassistant.components.mqtt.subscription import (
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_URL
-from homeassistant.core import Config, HomeAssistant, callback, valid_entity_id
+from homeassistant.core import HomeAssistant, callback, valid_entity_id
+from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession


### PR DESCRIPTION
The Config class moved to homeassistant.core_config in 2024.11.0b0.