### PR TITLE
refactor: Move proxy fuctionality to a common library

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -13,6 +13,6 @@
     "documentation": "https://github.com/blakeblackshear/frigate",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
-    "requirements": ["pytz"],
+    "requirements": ["hass-web-proxy-lib==0.0.6", "pytz"],
     "version": "5.4.1"
 }

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Mapping
 import datetime
-from http import HTTPStatus
-from ipaddress import ip_address
 import logging
 from typing import Any, Optional, cast
 
-import aiohttp
-from aiohttp import hdrs, web
-from aiohttp.web_exceptions import HTTPBadGateway, HTTPUnauthorized
+from aiohttp import web
+from hass_web_proxy_lib import (
+    HASSWebProxyLibForbiddenRequestError,
+    HASSWebProxyLibNotFoundRequestError,
+    HASSWebProxyLibUnauthorizedRequestError,
+    ProxiedURL,
+    ProxyView,
+    WebsocketProxyView,
+)
 import jwt
-from multidict import CIMultiDict
 from yarl import URL
 
 from custom_components.frigate.api import FrigateApiClient
@@ -27,7 +29,7 @@ from custom_components.frigate.const import (
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     DOMAIN,
 )
-from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
+from homeassistant.components.http import KEY_AUTHENTICATED
 from homeassistant.components.http.auth import DATA_SIGN_SECRET, SIGN_QUERY_PARAM
 from homeassistant.components.http.const import KEY_HASS
 from homeassistant.config_entries import ConfigEntry
@@ -112,21 +114,15 @@ def async_setup(hass: HomeAssistant) -> None:
     hass.http.register_view(VodSegmentProxyView(session))
 
 
-# These proxies are inspired by:
-#  - https://github.com/home-assistant/supervisor/blob/main/supervisor/api/ingress.py
+class FrigateProxyViewMixin:
+    """A mixin for proxying Frigate."""
 
-
-class ProxyView(HomeAssistantView):
-    """HomeAssistant view."""
-
-    requires_auth = True
-
-    def __init__(self, websession: aiohttp.ClientSession):
-        """Initialize the frigate clips proxy view."""
-        self._websession = websession
+    def _get_query_params(self, request: web.Request) -> Mapping[str, str]:
+        """Get the query params to send upstream."""
+        return {k: v for k, v in request.query.items() if k != "authSig"}
 
     def _get_config_entry_for_request(
-        self, request: web.Request, frigate_instance_id: str | None
+        self, request: web.Request, frigate_instance_id: str | None = None
     ) -> ConfigEntry | None:
         """Get a ConfigEntry for a given request."""
         hass = request.app[KEY_HASS]
@@ -135,86 +131,27 @@ class ProxyView(HomeAssistantView):
             return get_config_entry_for_frigate_instance_id(hass, frigate_instance_id)
         return get_default_config_entry(hass)
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        raise NotImplementedError  # pragma: no cover
-
-    def _permit_request(
-        self, request: web.Request, config_entry: ConfigEntry, **kwargs: Any
-    ) -> bool:
-        """Determine whether to permit a request."""
-        return True
-
-    async def get(
-        self,
-        request: web.Request,
-        **kwargs: Any,
-    ) -> web.Response | web.StreamResponse | web.WebSocketResponse:
-        """Route data to service."""
-        try:
-            return await self._handle_request(request, **kwargs)
-
-        except aiohttp.ClientError as err:
-            _LOGGER.debug("Reverse proxy error for %s: %s", request.rel_url, err)
-
-        raise HTTPBadGateway() from None
-
-    @staticmethod
-    def _get_query_params(request: web.Request) -> Mapping[str, str]:
-        """Get the query params to send upstream."""
-        return {k: v for k, v in request.query.items() if k != "authSig"}
-
-    async def _handle_request(
-        self,
-        request: web.Request,
-        frigate_instance_id: str | None = None,
-        **kwargs: Any,
-    ) -> web.Response | web.StreamResponse:
-        """Handle route for request."""
-        config_entry = self._get_config_entry_for_request(request, frigate_instance_id)
+    def _get_fqdn_path(
+        self, request: web.Request, path: str, frigate_instance_id: str | None = None
+    ) -> str:
+        """Get the fully qualified domain name path."""
+        config_entry = self._get_config_entry_for_request(
+            request, frigate_instance_id=frigate_instance_id
+        )
         if not config_entry:
-            return web.Response(status=HTTPStatus.BAD_REQUEST)
-
-        if not self._permit_request(request, config_entry, **kwargs):
-            return web.Response(status=HTTPStatus.FORBIDDEN)
-
-        full_path = self._create_path(**kwargs)
-        if not full_path:
-            return web.Response(status=HTTPStatus.NOT_FOUND)
-
-        url = str(URL(config_entry.data[CONF_URL]) / full_path)
-        data = await request.read()
-        source_header = _init_header(request)
-
-        async with self._websession.request(
-            request.method,
-            url,
-            headers=source_header,
-            params=self._get_query_params(request),
-            allow_redirects=False,
-            data=data,
-        ) as result:
-            headers = _response_header(result)
-
-            # Stream response
-            response = web.StreamResponse(status=result.status, headers=headers)
-            response.content_type = result.content_type
-
-            try:
-                await response.prepare(request)
-                async for data in result.content.iter_any():
-                    await response.write(data)
-
-            except (aiohttp.ClientError, aiohttp.ClientPayloadError) as err:
-                _LOGGER.debug("Stream error for %s: %s", request.rel_url, err)
-            except ConnectionResetError:
-                # Connection is reset/closed by peer.
-                pass
-
-            return response
+            raise HASSWebProxyLibNotFoundRequestError()
+        return str(URL(config_entry.data[CONF_URL]) / path)
 
 
-class SnapshotsProxyView(ProxyView):
+class FrigateProxyView(FrigateProxyViewMixin, ProxyView):
+    """A proxy for Frigate."""
+
+
+class FrigateWebsocketProxyView(FrigateProxyViewMixin, WebsocketProxyView):
+    """A websocket proxy for Frigate."""
+
+
+class SnapshotsProxyView(FrigateProxyView):
     """A proxy for snapshots."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/snapshot/{eventid:.*}"
@@ -222,12 +159,19 @@ class SnapshotsProxyView(ProxyView):
 
     name = "api:frigate:snapshots"
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"api/events/{kwargs['eventid']}/snapshot.jpg"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"api/events/{kwargs['eventid']}/snapshot.jpg",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
+        )
 
 
-class RecordingProxyView(ProxyView):
+class RecordingProxyView(FrigateProxyView):
     """A proxy for recordings."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/recording/{camera:.+}/start/{start:[.0-9]+}/end/{end:[.0-9]*}"
@@ -237,57 +181,90 @@ class RecordingProxyView(ProxyView):
 
     name = "api:frigate:recording"
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return (
-            f"api/{kwargs['camera']}/start/{kwargs['start']}"
-            + f"/end/{kwargs['end']}/clip.mp4"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"api/{kwargs['camera']}/start/{kwargs['start']}"
+                + f"/end/{kwargs['end']}/clip.mp4",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
         )
 
 
-class ThumbnailsProxyView(ProxyView):
+class ThumbnailsProxyView(FrigateProxyView):
     """A proxy for snapshots."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/thumbnail/{eventid:.*}"
 
     name = "api:frigate:thumbnails"
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"api/events/{kwargs['eventid']}/thumbnail.jpg"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"api/events/{kwargs['eventid']}/thumbnail.jpg",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
+        )
 
 
-class NotificationsProxyView(ProxyView):
+class NotificationsProxyView(FrigateProxyView):
     """A proxy for notifications."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/notifications/{event_id}/{path:.*}"
     extra_urls = ["/api/frigate/notifications/{event_id}/{path:.*}"]
 
     name = "api:frigate:notification"
-    requires_auth = False
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        path, event_id = kwargs["path"], kwargs["event_id"]
+    def _get_proxied_url(
+        self,
+        request: web.Request,
+        **kwargs: Any,
+    ) -> ProxiedURL:
+        """Create proxied URL."""
+        path: str = kwargs["path"]
+        event_id: str = kwargs["event_id"]
+
+        config_entry = self._get_config_entry_for_request(
+            request, kwargs.get("frigate_instance_id")
+        )
+        if not config_entry:
+            raise HASSWebProxyLibNotFoundRequestError("No Frigate instance found.")
+        if not self._permit_request(request, config_entry, event_id=event_id):
+            raise HASSWebProxyLibForbiddenRequestError("Request not permitted.")
+
+        url_path: str | None = None
         if path == "thumbnail.jpg":
-            return f"api/events/{event_id}/thumbnail.jpg"
+            url_path = f"api/events/{event_id}/thumbnail.jpg"
+        elif path == "snapshot.jpg":
+            url_path = f"api/events/{event_id}/snapshot.jpg"
+        elif path.endswith("clip.mp4"):
+            url_path = f"api/events/{event_id}/clip.mp4"
+        elif path.endswith("event_preview.gif"):
+            url_path = f"api/events/{event_id}/preview.gif"
+        elif path.endswith("review_preview.gif"):
+            url_path = f"api/review/{event_id}/preview"
 
-        if path == "snapshot.jpg":
-            return f"api/events/{event_id}/snapshot.jpg"
+        if not url_path:
+            raise HASSWebProxyLibNotFoundRequestError
 
-        if path.endswith("clip.mp4"):
-            return f"api/events/{event_id}/clip.mp4"
-
-        if path.endswith("event_preview.gif"):
-            return f"api/events/{event_id}/preview.gif"
-
-        if path.endswith("review_preview.gif"):
-            return f"api/review/{event_id}/preview"
-
-        return None
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                url_path,
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            allow_unauthenticated=True,
+            query_params=self._get_query_params(request),
+        )
 
     def _permit_request(
-        self, request: web.Request, config_entry: ConfigEntry, **kwargs: Any
+        self, request: web.Request, config_entry: ConfigEntry, event_id: str
     ) -> bool:
         """Determine whether to permit a request."""
 
@@ -313,7 +290,7 @@ class NotificationsProxyView(ProxyView):
             return True
 
         try:
-            event_id_timestamp = int(kwargs["event_id"].partition(".")[0])
+            event_id_timestamp = int(event_id.partition(".")[0])
             event_datetime = datetime.datetime.fromtimestamp(
                 event_id_timestamp, tz=datetime.timezone.utc
             )
@@ -325,13 +302,11 @@ class NotificationsProxyView(ProxyView):
             # Otherwise, permit only if notification event is not expired
             return now_datetime.timestamp() <= expiration_datetime.timestamp()
         except ValueError:
-            _LOGGER.warning(
-                "The event id %s does not have a valid format.", kwargs["event_id"]
-            )
+            _LOGGER.warning("The event id %s does not have a valid format.", event_id)
             return False
 
 
-class VodProxyView(ProxyView):
+class VodProxyView(FrigateProxyView):
     """A proxy for vod playlists."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/vod/{path:.+}/{manifest:.+}.m3u8"
@@ -339,30 +314,46 @@ class VodProxyView(ProxyView):
 
     name = "api:frigate:vod:manifest"
 
-    @staticmethod
-    def _get_query_params(request: web.Request) -> Mapping[str, str]:
+    def _get_query_params(self, request: web.Request) -> Mapping[str, str]:
         """Get the query params to send upstream."""
         return request.query
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"vod/{kwargs['path']}/{kwargs['manifest']}.m3u8"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"vod/{kwargs['path']}/{kwargs['manifest']}.m3u8",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
+        )
 
 
-class VodSegmentProxyView(ProxyView):
+class VodSegmentProxyView(FrigateProxyView):
     """A proxy for vod segments."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/vod/{path:.+}/{segment:.+}.{extension:(ts|m4s|mp4)}"
     extra_urls = ["/api/frigate/vod/{path:.+}/{segment:.+}.{extension:(ts|m4s|mp4)}"]
 
     name = "api:frigate:vod:segment"
-    requires_auth = False
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"vod/{kwargs['path']}/{kwargs['segment']}.{kwargs['extension']}"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        if not self._async_validate_signed_manifest(request):
+            raise HASSWebProxyLibUnauthorizedRequestError()
 
-    async def _async_validate_signed_manifest(self, request: web.Request) -> bool:
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"vod/{kwargs['path']}/{kwargs['segment']}.{kwargs['extension']}",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            allow_unauthenticated=True,
+            query_params=self._get_query_params(request),
+        )
+
+    def _async_validate_signed_manifest(self, request: web.Request) -> bool:
         """Validate the signature for the manifest of this segment."""
         hass = request.app[KEY_HASS]
         secret = str(hass.data.get(DATA_SIGN_SECRET))
@@ -388,98 +379,8 @@ class VodSegmentProxyView(ProxyView):
 
         return True
 
-    async def get(
-        self,
-        request: web.Request,
-        **kwargs: Any,
-    ) -> web.Response | web.StreamResponse | web.WebSocketResponse:
-        """Route data to service."""
 
-        if not await self._async_validate_signed_manifest(request):
-            raise HTTPUnauthorized()
-
-        return await super().get(request, **kwargs)
-
-
-class WebsocketProxyView(ProxyView):
-    """A simple proxy for websockets."""
-
-    async def _proxy_msgs(
-        self,
-        ws_in: aiohttp.ClientWebSocketResponse | web.WebSocketResponse,
-        ws_out: aiohttp.ClientWebSocketResponse | web.WebSocketResponse,
-    ) -> None:
-
-        async for msg in ws_in:
-            try:
-                if msg.type == aiohttp.WSMsgType.TEXT:
-                    await ws_out.send_str(msg.data)
-                elif msg.type == aiohttp.WSMsgType.BINARY:
-                    await ws_out.send_bytes(msg.data)
-                elif msg.type == aiohttp.WSMsgType.PING:
-                    await ws_out.ping()
-                elif msg.type == aiohttp.WSMsgType.PONG:
-                    await ws_out.pong()
-            except ConnectionResetError:
-                return
-
-    async def _handle_request(
-        self,
-        request: web.Request,
-        frigate_instance_id: str | None = None,
-        **kwargs: Any,
-    ) -> web.Response | web.StreamResponse:
-        """Handle route for request."""
-
-        config_entry = self._get_config_entry_for_request(request, frigate_instance_id)
-        if not config_entry:
-            return web.Response(status=HTTPStatus.BAD_REQUEST)
-
-        if not self._permit_request(request, config_entry, **kwargs):
-            return web.Response(status=HTTPStatus.FORBIDDEN)
-
-        full_path = self._create_path(**kwargs)
-        if not full_path:
-            return web.Response(status=HTTPStatus.NOT_FOUND)
-
-        req_protocols = []
-        if hdrs.SEC_WEBSOCKET_PROTOCOL in request.headers:
-            req_protocols = [
-                str(proto.strip())
-                for proto in request.headers[hdrs.SEC_WEBSOCKET_PROTOCOL].split(",")
-            ]
-
-        ws_to_user = web.WebSocketResponse(
-            protocols=req_protocols, autoclose=False, autoping=False
-        )
-        await ws_to_user.prepare(request)
-
-        # Preparing
-        url = str(URL(config_entry.data[CONF_URL]) / full_path)
-        source_header = _init_header(request)
-
-        # Support GET query
-        if request.query_string:
-            url = f"{url}?{request.query_string}"
-
-        async with self._websession.ws_connect(
-            url,
-            headers=source_header,
-            protocols=req_protocols,
-            autoclose=False,
-            autoping=False,
-        ) as ws_to_frigate:
-            await asyncio.wait(
-                [
-                    asyncio.create_task(self._proxy_msgs(ws_to_frigate, ws_to_user)),
-                    asyncio.create_task(self._proxy_msgs(ws_to_user, ws_to_frigate)),
-                ],
-                return_when=asyncio.tasks.FIRST_COMPLETED,
-            )
-        return ws_to_user
-
-
-class JSMPEGProxyView(WebsocketProxyView):
+class JSMPEGProxyView(FrigateWebsocketProxyView):
     """A proxy for JSMPEG websocket."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/jsmpeg/{path:.+}"
@@ -487,12 +388,19 @@ class JSMPEGProxyView(WebsocketProxyView):
 
     name = "api:frigate:jsmpeg"
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"live/jsmpeg/{kwargs['path']}"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"live/jsmpeg/{kwargs['path']}",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
+        )
 
 
-class MSEProxyView(WebsocketProxyView):
+class MSEProxyView(FrigateWebsocketProxyView):
     """A proxy for MSE websocket."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/mse/{path:.+}"
@@ -500,12 +408,19 @@ class MSEProxyView(WebsocketProxyView):
 
     name = "api:frigate:mse"
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"live/mse/{kwargs['path']}"
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"live/mse/{kwargs['path']}",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
+        )
 
 
-class WebRTCProxyView(WebsocketProxyView):
+class WebRTCProxyView(FrigateWebsocketProxyView):
     """A proxy for WebRTC websocket."""
 
     url = "/api/frigate/{frigate_instance_id:.+}/webrtc/{path:.+}"
@@ -513,75 +428,13 @@ class WebRTCProxyView(WebsocketProxyView):
 
     name = "api:frigate:webrtc"
 
-    def _create_path(self, **kwargs: Any) -> str | None:
-        """Create path."""
-        return f"live/webrtc/{kwargs['path']}"
-
-
-def _init_header(request: web.Request) -> CIMultiDict | dict[str, str]:
-    """Create initial header."""
-    headers = {}
-
-    # filter flags
-    for name, value in request.headers.items():
-        if name in (
-            hdrs.CONTENT_LENGTH,
-            hdrs.CONTENT_ENCODING,
-            hdrs.SEC_WEBSOCKET_EXTENSIONS,
-            hdrs.SEC_WEBSOCKET_PROTOCOL,
-            hdrs.SEC_WEBSOCKET_VERSION,
-            hdrs.SEC_WEBSOCKET_KEY,
-            hdrs.HOST,
-            hdrs.AUTHORIZATION,
-        ):
-            continue
-        headers[name] = value
-
-    # Set X-Forwarded-For
-    forward_for = request.headers.get(hdrs.X_FORWARDED_FOR)
-    assert request.transport
-    connected_ip = ip_address(request.transport.get_extra_info("peername")[0])
-    if forward_for:
-        forward_for = f"{forward_for}, {connected_ip!s}"
-    else:
-        forward_for = f"{connected_ip!s}"
-    headers[hdrs.X_FORWARDED_FOR] = forward_for
-
-    # Set X-Forwarded-Host
-    forward_host = request.headers.get(hdrs.X_FORWARDED_HOST)
-    if not forward_host:
-        forward_host = request.host
-    headers[hdrs.X_FORWARDED_HOST] = forward_host
-
-    # Set X-Forwarded-Proto
-    forward_proto = request.headers.get(hdrs.X_FORWARDED_PROTO)
-    if not forward_proto:
-        forward_proto = request.url.scheme
-    headers[hdrs.X_FORWARDED_PROTO] = forward_proto
-
-    return headers
-
-
-def _response_header(response: aiohttp.ClientResponse) -> dict[str, str]:
-    """Create response header."""
-    headers = {}
-
-    for name, value in response.headers.items():
-        if name in (
-            hdrs.TRANSFER_ENCODING,
-            # Removing Content-Length header for streaming responses
-            #   prevents seeking from working for mp4 files
-            # hdrs.CONTENT_LENGTH,
-            hdrs.CONTENT_TYPE,
-            hdrs.CONTENT_ENCODING,
-            # Strips inbound CORS response headers since the aiohttp_cors
-            # library will assert that they are not already present for CORS
-            # requests.
-            hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
-            hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
-            hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
-        ):
-            continue
-        headers[name] = value
-
-    return headers
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                f"live/webrtc/{kwargs['path']}",
+                frigate_instance_id=kwargs.get("frigate_instance_id"),
+            ),
+            query_params=self._get_query_params(request),
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ paho-mqtt
 python-dateutil
 yarl
 pytz
+hass-web-proxy-lib==0.0.6

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,21 +1,18 @@
-"""Test the frigate binary sensor."""
+"""Test the frigate views."""
 
 from __future__ import annotations
 
-import asyncio
 import copy
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 import logging
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
-import aiohttp
-from aiohttp import hdrs, web
-from aiohttp.web_exceptions import HTTPUnauthorized
+from aiohttp import web
+from hass_web_proxy_lib.tests.utils import response_handler, ws_response_handler
 import pytest
 
-from custom_components.frigate import views
 from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_MQTT,
@@ -23,9 +20,7 @@ from custom_components.frigate.const import (
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     DOMAIN,
 )
-from homeassistant.components.http.auth import async_setup_auth, async_sign_path
-from homeassistant.components.http.const import KEY_AUTHENTICATED
-from homeassistant.components.http.forwarded import async_setup_forwarded
+from homeassistant.components.http.auth import async_sign_path
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 
@@ -54,122 +49,38 @@ def _get_fixed_datetime() -> datetime:
 FIXED_TEST_DATETIME = _get_fixed_datetime()
 
 
-class ClientErrorStreamResponse(web.StreamResponse):
-    """StreamResponse for testing purposes that raises a ClientError."""
-
-    async def write(self, data: bytes) -> None:
-        """Write data."""
-        raise aiohttp.ClientError
-
-
-class ConnectionResetStreamResponse(web.StreamResponse):
-    """StreamResponse for testing purposes that raises a ConnectionResetError."""
-
-    async def write(self, data: bytes) -> None:
-        """Write data."""
-        raise ConnectionResetError
-
-
-class FakeAsyncContextManager:
-    """Fake AsyncContextManager for testing purposes."""
-
-    async def __aenter__(self, *args: Any, **kwargs: Any) -> FakeAsyncContextManager:
-        """Context manager enter."""
-        return self
-
-    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
-        """Context manager exit."""
-
-
-async def mock_handler(request: Any) -> Any:
-    """Return if request was authenticated."""
-    if not request[KEY_AUTHENTICATED]:
-        raise HTTPUnauthorized
-
-    user = request.get("hass_user")
-    user_id = user.id if user else None
-
-    return web.json_response(status=200, data={"user_id": user_id})
-
-
-@pytest.fixture
-def app(hass: HomeAssistant) -> Any:
-    """Fixture to set up a web.Application."""
-    app = web.Application()
-    app["hass"] = hass
-    app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, True, [])
-    return app
-
-
 @pytest.fixture
 async def local_frigate(hass: HomeAssistant, aiohttp_server: Any) -> Any:
     """Point the integration at a local fake Frigate server."""
 
-    def _assert_expected_headers(request: web.Request, allow_ws: bool = False) -> None:
-        assert hdrs.CONTENT_ENCODING not in request.headers
-
-        if not allow_ws:
-            for header in (
-                hdrs.SEC_WEBSOCKET_EXTENSIONS,
-                hdrs.SEC_WEBSOCKET_PROTOCOL,
-                hdrs.SEC_WEBSOCKET_VERSION,
-                hdrs.SEC_WEBSOCKET_KEY,
-            ):
-                assert header not in request.headers
-
-        for header in (
-            hdrs.X_FORWARDED_HOST,
-            hdrs.X_FORWARDED_PROTO,
-            hdrs.X_FORWARDED_FOR,
-        ):
-            assert header in request.headers
-
-    async def ws_qs_echo_handler(request: web.Request) -> web.WebSocketResponse:
-        """Verify the query string and act as echo handler."""
-        assert request.query["key"] == "value"
-        return await ws_echo_handler(request)
-
-    async def ws_echo_handler(request: web.Request) -> web.WebSocketResponse:
-        """Act as echo handler."""
-        _assert_expected_headers(request, allow_ws=True)
-
-        ws = web.WebSocketResponse()
-        await ws.prepare(request)
-
-        async for msg in ws:
-            if msg.type == aiohttp.WSMsgType.TEXT:
-                await ws.send_str(msg.data)
-            elif msg.type == aiohttp.WSMsgType.BINARY:
-                await ws.send_bytes(msg.data)
-        return ws
-
-    async def handler(request: web.Request) -> web.Response:
-        _assert_expected_headers(request)
-        return web.json_response({})
-
     server = await start_frigate_server(
         aiohttp_server,
         [
-            web.get("/vod/present/manifest.m3u8", handler),
-            web.get("/vod/present/segment.ts", handler),
-            web.get("/api/events/event_id/thumbnail.jpg", handler),
-            web.get("/api/events/event_id/snapshot.jpg", handler),
-            web.get("/api/events/event_id/clip.mp4", handler),
-            web.get("/api/events/event_id/preview.gif", handler),
-            web.get("/api/review/event_id/preview", handler),
-            web.get("/api/events/1577854800.123456-random/snapshot.jpg", handler),
-            web.get("/api/events/1635807600.123456-random/snapshot.jpg", handler),
-            web.get("/api/events/1635807359.123456-random/snapshot.jpg", handler),
-            web.get("/live/jsmpeg/front_door", ws_echo_handler),
-            web.get("/live/jsmpeg/querystring", ws_qs_echo_handler),
-            web.get("/live/mse/front_door", ws_echo_handler),
-            web.get("/live/mse/querystring", ws_qs_echo_handler),
-            web.get("/live/webrtc/front_door", ws_echo_handler),
-            web.get("/live/webrtc/querystring", ws_qs_echo_handler),
+            web.get("/vod/present/manifest.m3u8", response_handler),
+            web.get("/vod/present/segment.ts", response_handler),
+            web.get("/api/events/event_id/thumbnail.jpg", response_handler),
+            web.get("/api/events/event_id/snapshot.jpg", response_handler),
+            web.get("/api/events/event_id/clip.mp4", response_handler),
+            web.get("/api/events/event_id/preview.gif", response_handler),
+            web.get("/api/review/event_id/preview", response_handler),
+            web.get(
+                "/api/events/1577854800.123456-random/snapshot.jpg", response_handler
+            ),
+            web.get(
+                "/api/events/1635807600.123456-random/snapshot.jpg", response_handler
+            ),
+            web.get(
+                "/api/events/1635807359.123456-random/snapshot.jpg", response_handler
+            ),
+            web.get("/live/jsmpeg/front_door", ws_response_handler),
+            web.get("/live/jsmpeg/querystring", ws_response_handler),
+            web.get("/live/mse/front_door", ws_response_handler),
+            web.get("/live/mse/querystring", ws_response_handler),
+            web.get("/live/webrtc/front_door", ws_response_handler),
+            web.get("/live/webrtc/querystring", ws_response_handler),
             web.get(
                 "/api/front_door/start/1664067600.02/end/1664068200.03/clip.mp4",
-                handler,
+                response_handler,
             ),
         ],
     )
@@ -195,14 +106,11 @@ async def test_vod_manifest_proxy(
 
 async def test_vod_segment_proxy(
     hass: HomeAssistant,
-    app: Any,
     hass_access_token: Any,
     local_frigate: Any,
     hass_client: Any,
 ) -> None:
     """Test vod segment."""
-
-    await async_setup_auth(hass, app)
 
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     assert refresh_token
@@ -221,7 +129,6 @@ async def test_vod_segment_proxy(
 
 async def test_vod_segment_proxy_unauthorized(
     hass: HomeAssistant,
-    app: Any,
     hass_access_token: Any,
     local_frigate: Any,
     hass_client: Any,
@@ -233,8 +140,6 @@ async def test_vod_segment_proxy_unauthorized(
     # No secret set
     resp = await authenticated_hass_client.get("/api/frigate/vod/present/segment.ts")
     assert resp.status == HTTPStatus.UNAUTHORIZED
-
-    await async_setup_auth(hass, app)
 
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     assert refresh_token
@@ -254,6 +159,7 @@ async def test_vod_segment_proxy_unauthorized(
     resp = await authenticated_hass_client.get(
         "/api/frigate/vod/present/segment.ts?authSig=invalid"
     )
+    assert resp.status == HTTPStatus.UNAUTHORIZED
 
     # Modified path
     resp = await authenticated_hass_client.get(
@@ -262,7 +168,7 @@ async def test_vod_segment_proxy_unauthorized(
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
 
-async def test_snapshot_proxy_view_success(
+async def test_snapshot_proxy_view(
     local_frigate: Any,
     hass_client: Any,
 ) -> None:
@@ -275,58 +181,6 @@ async def test_snapshot_proxy_view_success(
 
     resp = await authenticated_hass_client.get("/api/frigate/snapshot/not_present")
     assert resp.status == HTTPStatus.NOT_FOUND
-
-
-async def test_snapshot_proxy_view_write_error(
-    caplog: Any, local_frigate: Any, hass_client: Any
-) -> None:
-    """Test snapshot request with a write error."""
-
-    authenticated_hass_client = await hass_client()
-
-    with patch(
-        "custom_components.frigate.views.web.StreamResponse",
-        new=ClientErrorStreamResponse,
-    ):
-        await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
-        assert "Stream error" in caplog.text
-
-
-async def test_snapshot_proxy_view_connection_reset(
-    caplog: Any, local_frigate: Any, hass_client: Any
-) -> None:
-    """Test snapshot request with a connection reset."""
-
-    authenticated_hass_client = await hass_client()
-
-    with patch(
-        "custom_components.frigate.views.web.StreamResponse",
-        new=ConnectionResetStreamResponse,
-    ):
-        await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
-        assert "Stream error" not in caplog.text
-
-
-async def test_snapshot_proxy_view_read_error(
-    hass: HomeAssistant,
-    caplog: Any,
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test snapshot request with a read error."""
-
-    mock_request = MagicMock(FakeAsyncContextManager())
-    mock_request.side_effect = aiohttp.ClientError
-
-    authenticated_hass_client = await hass_client()
-
-    with patch.object(
-        hass.helpers.aiohttp_client.async_get_clientsession(),
-        "request",
-        new=mock_request,
-    ):
-        await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
-        assert "Reverse proxy error" in caplog.text
 
 
 async def test_recordings_proxy_view(
@@ -427,29 +281,6 @@ async def test_notifications_proxy_other(
     assert resp.status == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.allow_proxy
-async def test_headers(
-    hass: Any,
-    local_frigate: Any,
-    hass_client_no_auth: Any,
-) -> None:
-    """Test proxy headers are added and respected."""
-
-    unauthenticated_hass_client = await hass_client_no_auth()
-
-    resp = await unauthenticated_hass_client.get(
-        "/api/frigate/notifications/event_id/thumbnail.jpg",
-        headers={hdrs.CONTENT_ENCODING: "foo"},
-    )
-    assert resp.status == HTTPStatus.OK
-
-    resp = await unauthenticated_hass_client.get(
-        "/api/frigate/notifications/event_id/thumbnail.jpg",
-        headers={hdrs.X_FORWARDED_FOR: "1.2.3.4"},
-    )
-    assert resp.status == HTTPStatus.OK
-
-
 async def test_snapshots_with_frigate_instance_id(
     local_frigate: Any,
     hass_client: Any,
@@ -472,12 +303,12 @@ async def test_snapshots_with_frigate_instance_id(
     resp = await authenticated_hass_client.get(
         "/api/frigate/NOT_A_REAL_ID/snapshot/event_id"
     )
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
-    # No default allowed when there are multiple entries.
+    # There is no default when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     resp = await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_thumbnails_with_frigate_instance_id(
@@ -502,7 +333,7 @@ async def test_thumbnails_with_frigate_instance_id(
     resp = await authenticated_hass_client.get(
         "/api/frigate/NOT_A_REAL_ID/thumbnail/event_id"
     )
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_vod_with_frigate_instance_id(
@@ -527,17 +358,16 @@ async def test_vod_with_frigate_instance_id(
     resp = await authenticated_hass_client.get(
         "/api/frigate/NOT_A_REAL_ID/vod/present/manifest.m3u8"
     )
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
-    # No default allowed when there are multiple entries.
+    # There is no default when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     resp = await authenticated_hass_client.get("/api/frigate/vod/present/manifest.m3u8")
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_vod_segment_with_frigate_instance_id(
     hass: HomeAssistant,
-    app: Any,
     hass_access_token: Any,
     local_frigate: Any,
     hass_client: Any,
@@ -546,8 +376,6 @@ async def test_vod_segment_with_frigate_instance_id(
 
     frigate_entries = hass.config_entries.async_entries(DOMAIN)
     assert frigate_entries
-
-    await async_setup_auth(hass, app)
 
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
     assert refresh_token
@@ -573,9 +401,9 @@ async def test_vod_segment_with_frigate_instance_id(
         refresh_token_id=refresh_token.id,
     )
     resp = await authenticated_hass_client.get(signed_path)
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
-    # No default allowed when there are multiple entries.
+    # There is no default when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     signed_path = async_sign_path(
         hass,
@@ -584,7 +412,7 @@ async def test_vod_segment_with_frigate_instance_id(
         refresh_token_id=refresh_token.id,
     )
     resp = await authenticated_hass_client.get(signed_path)
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_notifications_with_frigate_instance_id(
@@ -610,14 +438,14 @@ async def test_notifications_with_frigate_instance_id(
     resp = await unauthenticated_hass_client.get(
         "/api/frigate/NOT_A_REAL_ID/notifications/event_id/snapshot.jpg"
     )
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
-    # No default allowed when there are multiple entries.
+    # There is no default when there are multiple entries.
     create_mock_frigate_config_entry(hass, entry_id="another_id")
     resp = await unauthenticated_hass_client.get(
         "/api/frigate/notifications/event_id/snapshot.jpg"
     )
-    assert resp.status == HTTPStatus.BAD_REQUEST
+    assert resp.status == HTTPStatus.NOT_FOUND
 
 
 async def test_notifications_with_disabled_option(
@@ -786,351 +614,64 @@ async def test_expired_notifications_are_served_when_authenticated(
         assert resp.status == HTTPStatus.OK
 
 
-async def test_jsmpeg_text_binary(
-    local_frigate: Any,
+async def test_jsmpeg_ws_proxy_view(
     hass: Any,
+    local_frigate: Any,
     hass_client: Any,
 ) -> None:
-    """Test JSMPEG proxying text/binary data."""
+    """Test JSMPEG proxying."""
 
     authenticated_hass_client = await hass_client()
 
     async with authenticated_hass_client.ws_connect(
         f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door"
     ) as ws:
-        # Test sending text data.
-        result = await asyncio.gather(
-            ws.send_str("hello!"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.TEXT
-        assert result[1].data == "hello!"
+        # First message from the fixture will be the URL and headers.
+        request = await ws.receive_json()
+        assert request["url"].endswith("/live/jsmpeg/front_door")
 
-        # Test sending binary data.
-        result = await asyncio.gather(
-            ws.send_bytes(b"\x00\x01"),
-            ws.receive(),
-        )
-
-        assert result[1].type == aiohttp.WSMsgType.BINARY
-        assert result[1].data == b"\x00\x01"
+        # Subsequent messages will echo back.
+        await ws.send_str("Hello!")
+        assert (await ws.receive_str()) == "Hello!"
 
 
-async def test_jsmpeg_frame_type_ping_pong(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test JSMPEG proxying handles ping-pong."""
-
-    authenticated_hass_client = await hass_client()
-
-    async with authenticated_hass_client.ws_connect(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door"
-    ) as ws:
-        await ws.ping()
-
-        # Push some data through after the ping.
-        result = await asyncio.gather(
-            ws.send_bytes(b"\x00\x01"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.BINARY
-        assert result[1].data == b"\x00\x01"
-
-
-async def test_jsmpeg_connection_reset(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test JSMPEG proxying handles connection resets."""
-
-    # Tricky: This test is intended to test a ConnectionResetError to the
-    # Frigate server, which is the _second_ call to send*. The first call (from
-    # this test) needs to succeed.
-    real_send_str = views.aiohttp.web.WebSocketResponse.send_str
-
-    called_once = False
-
-    async def send_str(*args: Any, **kwargs: Any) -> None:
-        nonlocal called_once
-        if called_once:
-            raise ConnectionResetError
-        else:
-            called_once = True
-            return await real_send_str(*args, **kwargs)
-
-    authenticated_hass_client = await hass_client()
-
-    with patch(
-        "custom_components.frigate.views.aiohttp.ClientWebSocketResponse.send_str",
-        new=send_str,
-    ):
-        async with authenticated_hass_client.ws_connect(
-            f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door"
-        ) as ws:
-            await ws.send_str("data")
-
-
-async def test_mse_text_binary(
-    local_frigate: Any,
+async def test_mse_ws_proxy_view(
     hass: Any,
+    local_frigate: Any,
     hass_client: Any,
 ) -> None:
-    """Test JSMPEG proxying text/binary data."""
+    """Test MSE proxying."""
 
     authenticated_hass_client = await hass_client()
 
     async with authenticated_hass_client.ws_connect(
         f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/mse/front_door"
     ) as ws:
-        # Test sending text data.
-        result = await asyncio.gather(
-            ws.send_str("hello!"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.TEXT
-        assert result[1].data == "hello!"
+        # First message from the fixture will be the URL and headers.
+        request = await ws.receive_json()
+        assert request["url"].endswith("/live/mse/front_door")
 
-        # Test sending binary data.
-        result = await asyncio.gather(
-            ws.send_bytes(b"\x00\x01"),
-            ws.receive(),
-        )
-
-        assert result[1].type == aiohttp.WSMsgType.BINARY
-        assert result[1].data == b"\x00\x01"
+        # Subsequent messages will echo back.
+        await ws.send_str("Hello!")
+        assert (await ws.receive_str()) == "Hello!"
 
 
-async def test_mse_frame_type_ping_pong(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test JSMPEG proxying handles ping-pong."""
-
-    authenticated_hass_client = await hass_client()
-
-    async with authenticated_hass_client.ws_connect(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/mse/front_door"
-    ) as ws:
-        await ws.ping()
-
-        # Push some data through after the ping.
-        result = await asyncio.gather(
-            ws.send_bytes(b"\x00\x01"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.BINARY
-        assert result[1].data == b"\x00\x01"
-
-
-async def test_mse_connection_reset(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test JSMPEG proxying handles connection resets."""
-
-    # Tricky: This test is intended to test a ConnectionResetError to the
-    # Frigate server, which is the _second_ call to send*. The first call (from
-    # this test) needs to succeed.
-    real_send_str = views.aiohttp.web.WebSocketResponse.send_str
-
-    called_once = False
-
-    async def send_str(*args: Any, **kwargs: Any) -> None:
-        nonlocal called_once
-        if called_once:
-            raise ConnectionResetError
-        else:
-            called_once = True
-            return await real_send_str(*args, **kwargs)
-
-    authenticated_hass_client = await hass_client()
-
-    with patch(
-        "custom_components.frigate.views.aiohttp.ClientWebSocketResponse.send_str",
-        new=send_str,
-    ):
-        async with authenticated_hass_client.ws_connect(
-            f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/mse/front_door"
-        ) as ws:
-            await ws.send_str("data")
-
-
-async def test_webrtc_text_binary(
-    local_frigate: Any,
+async def test_webrtc_ws_proxy_view(
     hass: Any,
+    local_frigate: Any,
     hass_client: Any,
 ) -> None:
-    """Test JSMPEG proxying text/binary data."""
+    """Test WebRTC proxying."""
 
     authenticated_hass_client = await hass_client()
 
     async with authenticated_hass_client.ws_connect(
         f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/webrtc/front_door"
     ) as ws:
-        # Test sending text data.
-        result = await asyncio.gather(
-            ws.send_str("hello!"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.TEXT
-        assert result[1].data == "hello!"
+        # First message from the fixture will be the URL and headers.
+        request = await ws.receive_json()
+        assert request["url"].endswith("/live/webrtc/front_door")
 
-        # Test sending binary data.
-        result = await asyncio.gather(
-            ws.send_bytes(b"\x00\x01"),
-            ws.receive(),
-        )
-
-        assert result[1].type == aiohttp.WSMsgType.BINARY
-        assert result[1].data == b"\x00\x01"
-
-
-async def test_webrtc_frame_type_ping_pong(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test JSMPEG proxying handles ping-pong."""
-
-    authenticated_hass_client = await hass_client()
-
-    async with authenticated_hass_client.ws_connect(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/webrtc/front_door"
-    ) as ws:
-        await ws.ping()
-
-        # Push some data through after the ping.
-        result = await asyncio.gather(
-            ws.send_bytes(b"\x00\x01"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.BINARY
-        assert result[1].data == b"\x00\x01"
-
-
-async def test_webrtc_connection_reset(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test JSMPEG proxying handles connection resets."""
-
-    # Tricky: This test is intended to test a ConnectionResetError to the
-    # Frigate server, which is the _second_ call to send*. The first call (from
-    # this test) needs to succeed.
-    real_send_str = views.aiohttp.web.WebSocketResponse.send_str
-
-    called_once = False
-
-    async def send_str(*args: Any, **kwargs: Any) -> None:
-        nonlocal called_once
-        if called_once:
-            raise ConnectionResetError
-        else:
-            called_once = True
-            return await real_send_str(*args, **kwargs)
-
-    authenticated_hass_client = await hass_client()
-
-    with patch(
-        "custom_components.frigate.views.aiohttp.ClientWebSocketResponse.send_str",
-        new=send_str,
-    ):
-        async with authenticated_hass_client.ws_connect(
-            f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/webrtc/front_door"
-        ) as ws:
-            await ws.send_str("data")
-
-
-async def test_ws_proxy_specify_protocol(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test websocket proxy handles the SEC_WEBSOCKET_PROTOCOL header."""
-
-    authenticated_hass_client = await hass_client()
-
-    ws = await authenticated_hass_client.ws_connect(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door",
-        headers={hdrs.SEC_WEBSOCKET_PROTOCOL: "foo,bar"},
-    )
-    assert ws
-    await ws.close()
-
-
-async def test_ws_proxy_query_string(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test websocket proxy passes on the querystring."""
-
-    authenticated_hass_client = await hass_client()
-
-    async with authenticated_hass_client.ws_connect(
-        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/querystring?key=value",
-    ) as ws:
-        result = await asyncio.gather(
-            ws.send_str("hello!"),
-            ws.receive(),
-        )
-        assert result[1].type == aiohttp.WSMsgType.TEXT
-        assert result[1].data == "hello!"
-
-
-async def test_ws_proxy_bad_instance_id(
-    local_frigate: Any,
-    hass_client: Any,
-) -> None:
-    """Test websocket proxy handles bad instance id."""
-
-    authenticated_hass_client = await hass_client()
-
-    resp = await authenticated_hass_client.get(
-        "/api/frigate/NOT_A_REAL_ID/jsmpeg/front_door"
-    )
-    assert resp.status == HTTPStatus.BAD_REQUEST
-
-
-async def test_ws_proxy_forbidden(
-    local_frigate: Any,
-    hass_client: Any,
-    hass: Any,
-) -> None:
-    """Test websocket proxy handles forbidden paths."""
-
-    # Note: The ability to forbid websocket proxy calls is currently not used,
-    # but included for completeness and feature combatability with the other
-    # proxies. As such, there's no 'genuine' way to test this other than mocking
-    # out the call to _permit_request.
-
-    authenticated_hass_client = await hass_client()
-
-    with patch(
-        "custom_components.frigate.views.WebsocketProxyView._permit_request",
-        return_value=False,
-    ):
-        resp = await authenticated_hass_client.get(
-            f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door"
-        )
-        assert resp.status == HTTPStatus.FORBIDDEN
-
-
-async def test_ws_proxy_missing_path(
-    local_frigate: Any,
-    hass_client: Any,
-    hass: Any,
-) -> None:
-    """Test websocket proxy handles missing/invalid paths."""
-
-    authenticated_hass_client = await hass_client()
-
-    # Note: With current uses of the WebsocketProxy it's not possible to have a
-    # bad/missing path. Since that may not be the case in future for other views
-    # that inherit from WebsocketProxyView, this is tested here.
-    with patch(
-        "custom_components.frigate.views.JSMPEGProxyView._create_path",
-        return_value=None,
-    ):
-        resp = await authenticated_hass_client.get(
-            f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/jsmpeg/front_door"
-        )
-        assert resp.status == HTTPStatus.NOT_FOUND
+        # Subsequent messages will echo back.
+        await ws.send_str("Hello!")
+        assert (await ws.receive_str()) == "Hello!"


### PR DESCRIPTION
* Remove all proxying logic to a separate library [`hass-web-proxy-lib`](https://github.com/dermotduffy/hass-web-proxy-lib)
* Remove all testing that is not pertinent to what is being proxied.
* This library can then be used by other integrations (e.g. [`hass-web-proxy-integration`](https://github.com/dermotduffy/hass-web-proxy-integration) ).
* No material changes to actual Frigate proxying intended, beyond certain requests returning `NOT_FOUND` instead of `BAD_REQUEST` .