### PR TITLE
fix: Fix live streaming in HA >= `2024.11`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/devcontainers/python:1-3.10
+FROM mcr.microsoft.com/devcontainers/python:1-3.12
 
 CMD ["sleep", "infinity"]

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -44,6 +44,7 @@ from .const import (
     ATTR_WS_EVENT_PROXY,
     ATTRIBUTE_LABELS,
     CONF_CAMERA_STATIC_IMAGE_HEIGHT,
+    CONF_ENABLE_WEBRTC,
     DOMAIN,
     FRIGATE_RELEASES_URL,
     FRIGATE_VERSION_ERROR_CUTOFF,
@@ -263,10 +264,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if entity_id:
             entity_registry.async_remove(entity_id)
 
-    # Remove old `camera_image_height` option.
-    if CONF_CAMERA_STATIC_IMAGE_HEIGHT in entry.options:
+    # Remove old options.
+    OLD_OPTIONS = [CONF_CAMERA_STATIC_IMAGE_HEIGHT, CONF_ENABLE_WEBRTC]
+    if any(option in entry.options for option in OLD_OPTIONS):
         new_options = entry.options.copy()
-        new_options.pop(CONF_CAMERA_STATIC_IMAGE_HEIGHT)
+        for option in OLD_OPTIONS:
+            new_options.pop(option, None)
         hass.config_entries.async_update_entry(entry, options=new_options)
 
     # Cleanup object_motion sensors (replaced with occupancy sensors).

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -17,7 +17,6 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import FrigateApiClient, FrigateApiClientError
 from .const import (
-    CONF_ENABLE_WEBRTC,
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
@@ -124,14 +123,6 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_abort(reason="only_advanced_options")
 
         schema: dict[Any, Any] = {
-            # Whether to enable webrtc as the medium for camera streaming
-            vol.Optional(
-                CONF_ENABLE_WEBRTC,
-                default=self._config_entry.options.get(
-                    CONF_ENABLE_WEBRTC,
-                    False,
-                ),
-            ): bool,
             # The input URL is not validated as being a URL to allow for the
             # possibility the template input won't be a valid URL until after
             # it's rendered.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,7 +9,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
-    CONF_ENABLE_WEBRTC,
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
@@ -179,7 +178,6 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                CONF_ENABLE_WEBRTC: True,
                 CONF_RTMP_URL_TEMPLATE: "http://moo",
                 CONF_RTSP_URL_TEMPLATE: "http://moo",
                 CONF_NOTIFICATION_PROXY_ENABLE: False,
@@ -189,7 +187,6 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["data"][CONF_ENABLE_WEBRTC] is True
         assert result["data"][CONF_RTMP_URL_TEMPLATE] == "http://moo"
         assert result["data"][CONF_RTSP_URL_TEMPLATE] == "http://moo"
         assert result["data"][CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS] == 60

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,7 +14,11 @@ from custom_components.frigate import (
     get_frigate_entity_unique_id,
 )
 from custom_components.frigate.api import FrigateApiClientError
-from custom_components.frigate.const import CONF_CAMERA_STATIC_IMAGE_HEIGHT, DOMAIN
+from custom_components.frigate.const import (
+    CONF_CAMERA_STATIC_IMAGE_HEIGHT,
+    CONF_ENABLE_WEBRTC,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant
@@ -439,6 +443,21 @@ async def test_entry_remove_old_image_height_option(hass: HomeAssistant) -> None
 
     assert config_entry
     assert CONF_CAMERA_STATIC_IMAGE_HEIGHT not in config_entry.options
+
+
+async def test_entry_remove_old_enable_webrtc_(hass: HomeAssistant) -> None:
+    """Test cleanup of old enable webrtc option."""
+
+    mock_config_entry = create_mock_frigate_config_entry(
+        hass, options={CONF_ENABLE_WEBRTC: True}
+    )
+
+    await setup_mock_frigate_config_entry(hass, mock_config_entry)
+
+    config_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+
+    assert config_entry
+    assert CONF_ENABLE_WEBRTC not in config_entry.options
 
 
 async def test_entry_remove_old_devices(hass: HomeAssistant) -> None:


### PR DESCRIPTION
* Removes the `enable_webrtc` option entirely.
* **Note**: Also removes the `restream_type` attribute which is now rather meaningless.
* Closes #761 