### PR TITLE
chore: Bump `hass-web-proxy-lib` to `v0.0.7`

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -15,6 +15,6 @@
     "documentation": "https://github.com/blakeblackshear/frigate",
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
-    "requirements": ["hass-web-proxy-lib==0.0.6", "pytz"],
+    "requirements": ["hass-web-proxy-lib==0.0.7", "pytz"],
     "version": "5.4.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ paho-mqtt
 python-dateutil
 yarl
 pytz
-hass-web-proxy-lib==0.0.6
+hass-web-proxy-lib==0.0.7


### PR DESCRIPTION
* Commit history of underlying library: https://github.com/dermotduffy/hass-web-proxy-lib/commits/main/
* Main difference: Removes [homeassistant](https://pypi.org/project/homeassistant/) library as a runtime dependency (see #762)


