### PR TITLE
Correctly handle cameras that are not streaming

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -353,26 +353,23 @@ class BirdseyeCamera(FrigateEntity, Camera):
         # The device_class is used to filter out regular camera entities
         # from motion camera entities on selectors
         self._attr_device_class = DEVICE_CLASS_CAMERA
-        self._attr_is_streaming = self._frigate_config.get("birdseye", {}).get(
-            "restream", False
-        )
+        self._attr_is_streaming = True
         self._attr_is_recording = False
 
-        if self._attr_is_streaming:
-            streaming_template = config_entry.options.get(
-                CONF_RTSP_URL_TEMPLATE, ""
-            ).strip()
+        streaming_template = config_entry.options.get(
+            CONF_RTSP_URL_TEMPLATE, ""
+        ).strip()
 
-            if streaming_template:
-                # Can't use homeassistant.helpers.template as it requires hass which
-                # is not available in the constructor, so use direct jinja2
-                # template instead. This means templates cannot access HomeAssistant
-                # state, but rather only the camera config.
-                self._stream_source = Template(streaming_template).render(
-                    {"name": "birdseye"}
-                )
-            else:
-                self._stream_source = f"rtsp://{URL(self._url).host}:8554/birdseye"
+        if streaming_template:
+            # Can't use homeassistant.helpers.template as it requires hass which
+            # is not available in the constructor, so use direct jinja2
+            # template instead. This means templates cannot access HomeAssistant
+            # state, but rather only the camera config.
+            self._stream_source = Template(streaming_template).render(
+                {"name": "birdseye"}
+            )
+        else:
+            self._stream_source = f"rtsp://{URL(self._url).host}:8554/birdseye"
 
     @property
     def unique_id(self) -> str:
@@ -400,8 +397,6 @@ class BirdseyeCamera(FrigateEntity, Camera):
     @property
     def supported_features(self) -> CameraEntityFeature:
         """Return supported features of this camera."""
-        if not self._attr_is_streaming:
-            return CameraEntityFeature(0)
         return CameraEntityFeature.STREAM
 
     async def async_camera_image(

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -265,6 +265,8 @@ class FrigateCamera(
     @property
     def supported_features(self) -> CameraEntityFeature:
         """Return supported features of this camera."""
+        if not self._attr_is_streaming:
+            return CameraEntityFeature(0)
         return CameraEntityFeature.STREAM
 
     async def async_camera_image(

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -174,6 +174,23 @@ async def test_frigate_camera_birdseye_image_height(
     assert image.content == b"data-no-height"
 
 
+async def test_frigate_camera_setup_no_stream(hass: HomeAssistant) -> None:
+    """Set up a camera without streaming."""
+
+    config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
+    config["go2rtc"] = {}
+    client = create_mock_frigate_client()
+    client.async_get_config = AsyncMock(return_value=config)
+    await setup_mock_frigate_config_entry(hass, client=client)
+
+    entity_state = hass.states.get(TEST_CAMERA_FRONT_DOOR_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "idle"
+    assert not entity_state.attributes["supported_features"]
+
+    assert not await async_get_stream_source(hass, TEST_CAMERA_FRONT_DOOR_ENTITY_ID)
+
+
 async def test_frigate_camera_recording_camera_state(
     hass: HomeAssistant,
     aioclient_mock: Any,
@@ -181,7 +198,6 @@ async def test_frigate_camera_recording_camera_state(
     """Set up an mqtt camera."""
 
     config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
-    config["go2rtc"] = {}
     client = create_mock_frigate_client()
     client.async_get_config = AsyncMock(return_value=config)
     await setup_mock_frigate_config_entry(hass, client=client)


### PR DESCRIPTION
- Refs https://github.com/blakeblackshear/frigate-hass-integration/pull/776#discussion_r1859123083

This partially reverts https://github.com/blakeblackshear/frigate-hass-integration/pull/776, ~but also handles the case when birdseye would not be streaming (important to remember that birdseye doesn't even have streaming enabled by default)~ (EDIT: this was a mistake, birdseye entity is not even added if `birdseye.restream` is not enabled).

The rationale is: indeed, it is possible to have cameras in Frigate without streaming capabilities (i.e. if you don't have the camera set in your go2rtc).