### PR TITLE
Add support for proxying HLS clips for events

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -245,6 +245,8 @@ class NotificationsProxyView(FrigateProxyView):
             url_path = f"api/events/{event_id}/snapshot.jpg"
         elif path.endswith("clip.mp4"):
             url_path = f"api/events/{event_id}/clip.mp4"
+        elif path.endswith("master.m3u8"):
+            url_path = f"vod/events/{event_id}/master.m3u8"
         elif path.endswith("event_preview.gif"):
             url_path = f"api/events/{event_id}/preview.gif"
         elif path.endswith("review_preview.gif"):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -61,6 +61,7 @@ async def local_frigate(hass: HomeAssistant, aiohttp_server: Any) -> Any:
             web.get("/api/events/event_id/thumbnail.jpg", response_handler),
             web.get("/api/events/event_id/snapshot.jpg", response_handler),
             web.get("/api/events/event_id/clip.mp4", response_handler),
+            web.get("/vod/events/event_id/master.m3u8", response_handler),
             web.get("/api/events/event_id/preview.gif", response_handler),
             web.get("/api/review/event_id/preview", response_handler),
             web.get(
@@ -252,6 +253,7 @@ async def test_notifications_proxy_view_review_preview(
     )
     assert resp.status == HTTPStatus.OK
 
+
 async def test_notifications_proxy_view_hls(
     local_frigate: Any,
     hass_client_no_auth: Any,
@@ -264,6 +266,7 @@ async def test_notifications_proxy_view_hls(
         "/api/frigate/notifications/event_id/camera/master.m3u8"
     )
     assert resp.status == HTTPStatus.OK
+
 
 async def test_notifications_proxy_view_clip(
     local_frigate: Any,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -252,6 +252,18 @@ async def test_notifications_proxy_view_review_preview(
     )
     assert resp.status == HTTPStatus.OK
 
+async def test_notifications_proxy_view_hls(
+    local_frigate: Any,
+    hass_client_no_auth: Any,
+) -> None:
+    """Test notification HLS."""
+
+    unauthenticated_hass_client = await hass_client_no_auth()
+
+    resp = await unauthenticated_hass_client.get(
+        "/api/frigate/notifications/event_id/camera/master.m3u8"
+    )
+    assert resp.status == HTTPStatus.OK
 
 async def test_notifications_proxy_view_clip(
     local_frigate: Any,


### PR DESCRIPTION
This will make it so Safari users can play back clips using HLS directly