### PR TITLE
Fix minor issues with authentication flow

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -60,8 +60,8 @@ async def test_user_success(hass: HomeAssistant) -> None:
     assert result["title"] == "example.com"
     assert result["data"] == {
         CONF_URL: TEST_URL,
-        CONF_PASSWORD: None,
-        CONF_USERNAME: None,
+        CONF_PASSWORD: "",
+        CONF_USERNAME: "",
     }
     assert len(mock_setup_entry.mock_calls) == 1
     assert mock_client.async_get_stats.called


### PR DESCRIPTION
Fix two issues (both my fault):

- In my [reconfigure PR](https://github.com/blakeblackshear/frigate-hass-integration/pull/802) I referred to the wrong step, breaking translations.
- In @loispostula 's [auth PR](https://github.com/blakeblackshear/frigate-hass-integration/pull/801), I suggested using `None` instead of empty strings -- turns out the frontend cannot serialize `vol.Any(str, None)`, so this PR retreats to the use of empty strings which the frontend can serialize.
