### PR TITLE
Fix logos

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -121,7 +121,7 @@ def get_cameras_and_objects(
 
             if (
                 config.get("version", "0.14") < "0.16"
-                and obj in cam_config["model"]["all_attributes"]
+                and obj in config["model"]["all_attributes"]
             ):
                 # Logo attributes are only supported in Frigate 0.16+
                 continue

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -48,13 +48,11 @@ from .const import (
     ATTR_CONFIG,
     ATTR_COORDINATOR,
     ATTR_WS_EVENT_PROXY,
-    ATTRIBUTE_LABELS,
     CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_RTMP_URL_TEMPLATE,
     DOMAIN,
     FRIGATE_RELEASES_URL,
     FRIGATE_VERSION_ERROR_CUTOFF,
-    LOGO_LABELS,
     NAME,
     PLATFORMS,
     STARTUP_MESSAGE,
@@ -117,12 +115,17 @@ def get_cameras_and_objects(
     camera_objects = set()
     for cam_name, cam_config in config["cameras"].items():
         for obj in cam_config["objects"]["track"]:
-            if obj in ATTRIBUTE_LABELS:
+            if obj in config["model"]["non_logo_attributes"]:
+                # don't create sensors for attributes that are not logos
                 continue
 
-            if config.get("version", "0.14") < "0.16" and obj in LOGO_LABELS:
+            if (
+                config.get("version", "0.14") < "0.16"
+                and obj in cam_config["model"]["all_attributes"]
+            ):
+                # Logo attributes are only supported in Frigate 0.16+
                 continue
-                
+
             camera_objects.add((cam_name, obj))
 
         # add an artificial all label to track

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -54,6 +54,7 @@ from .const import (
     DOMAIN,
     FRIGATE_RELEASES_URL,
     FRIGATE_VERSION_ERROR_CUTOFF,
+    LOGO_LABELS,
     NAME,
     PLATFORMS,
     STARTUP_MESSAGE,
@@ -116,8 +117,16 @@ def get_cameras_and_objects(
     camera_objects = set()
     for cam_name, cam_config in config["cameras"].items():
         for obj in cam_config["objects"]["track"]:
-            if obj not in ATTRIBUTE_LABELS:
-                camera_objects.add((cam_name, obj))
+            if obj in ATTRIBUTE_LABELS:
+                continue
+
+            if (
+                config.get("version", "0.14") < "0.16"
+                and obj in LOGO_LABELS
+            ):
+                continue
+                
+            camera_objects.add((cam_name, obj))
 
         # add an artificial all label to track
         # all objects for this camera

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -120,10 +120,7 @@ def get_cameras_and_objects(
             if obj in ATTRIBUTE_LABELS:
                 continue
 
-            if (
-                config.get("version", "0.14") < "0.16"
-                and obj in LOGO_LABELS
-            ):
+            if config.get("version", "0.14") < "0.16" and obj in LOGO_LABELS:
                 continue
                 
             camera_objects.add((cam_name, obj))

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -135,7 +135,7 @@ class FrigateObjectOccupancySensor(FrigateMQTTEntity, BinarySensorEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{self._obj_name} occupancy"
+        return f"{get_friendly_name(self._obj_name)} occupancy"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -49,7 +49,9 @@ ATTR_INCLUDE_RECORDING = "include_recording"
 # Frigate Attribute Labels
 # These are labels that are not individually tracked as they are
 # attributes of another label. ex: face is an attribute of person
-ATTRIBUTE_LABELS = ["amazon", "face", "fedex", "license_plate", "ups"]
+# Logo labels only have sensors in 0.16+
+ATTRIBUTE_LABELS = ["face", "license_plate"]
+LOGO_LABELS = ["amazon", "fedex", "ups"]
 
 # Configuration and options
 CONF_MEDIA_BROWSER_ENABLE = "media_browser_enable"

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -46,13 +46,6 @@ ATTR_SUB_LABEL = "sub_label"
 ATTR_DURATION = "duration"
 ATTR_INCLUDE_RECORDING = "include_recording"
 
-# Frigate Attribute Labels
-# These are labels that are not individually tracked as they are
-# attributes of another label. ex: face is an attribute of person
-# Logo labels only have sensors in 0.16+
-ATTRIBUTE_LABELS = ["face", "license_plate"]
-LOGO_LABELS = ["amazon", "fedex", "ups"]
-
 # Configuration and options
 CONF_MEDIA_BROWSER_ENABLE = "media_browser_enable"
 CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"

--- a/custom_components/frigate/image.py
+++ b/custom_components/frigate/image.py
@@ -111,7 +111,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, ImageEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return self._obj_name.title()
+        return get_friendly_name(self._obj_name).title()
 
     @property
     def image_last_updated(self) -> datetime.datetime | None:

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -617,7 +617,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{self._obj_name} count"
+        return f"{get_friendly_name(self._obj_name)} count"
 
     @property
     def state(self) -> int:
@@ -704,7 +704,7 @@ class FrigateActiveObjectCountSensor(FrigateMQTTEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{self._obj_name} active count".title()
+        return f"{get_friendly_name(self._obj_name)} active count".title()
 
     @property
     def state(self) -> int:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -129,7 +129,11 @@ TEST_CONFIG = {
                     }
                 },
                 "mask": None,
-                "track": ["amazon", "car", "person"],
+                "track": [
+                    "amazon",
+                    "car",
+                    "person",
+                ],  # need to have car and logo for tests
             },
             "onvif": {
                 "autotracking": {
@@ -162,7 +166,27 @@ TEST_CONFIG = {
     },
     "environment_vars": {},
     "logger": {"default": "INFO", "logs": {}},
-    "model": {"height": 320, "width": 320},
+    "model": {
+        "height": 320,
+        "width": 320,
+        "all_attributes": [
+            "gls",
+            "purolator",
+            "usps",
+            "dpd",
+            "amazon",
+            "postnl",
+            "face",
+            "fedex",
+            "dhl",
+            "postnord",
+            "an_post",
+            "license_plate",
+            "nzpost",
+            "ups",
+        ],
+        "non_logo_attributes": ["face", "license_plate"],
+    },
     "mqtt": {
         "client_id": TEST_FRIGATE_INSTANCE_ID,
         "host": "mqtt",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -129,7 +129,7 @@ TEST_CONFIG = {
                     }
                 },
                 "mask": None,
-                "track": ["person"],
+                "track": ["amazon", "car", "person"],
             },
             "onvif": {
                 "autotracking": {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -131,9 +131,8 @@ TEST_CONFIG = {
                 "mask": None,
                 "track": [
                     "amazon",
-                    "car",
                     "person",
-                ],  # need to have car and logo for tests
+                ],  # need to have logo for tests
             },
             "onvif": {
                 "autotracking": {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -131,6 +131,7 @@ TEST_CONFIG = {
                 "mask": None,
                 "track": [
                     "amazon",
+                    "face",
                     "person",
                 ],  # need to have logo for tests
             },

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -558,3 +558,27 @@ async def test_entry_rename_entities_with_unusual_names(hass: HomeAssistant) -> 
     # Verify the rename has correctly occurred.
     entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, unique_id)
     assert entity_id == "sensor.front_door_person_count"
+
+
+async def test_older_frigate_no_logo_sensors(hass: HomeAssistant) -> None:
+    """Test that non-simple names work."""
+    config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
+
+    # Rename one camera.
+    config["version"] = "0.15-1"
+
+    client = create_mock_frigate_client()
+    client.async_get_config = AsyncMock(return_value=config)
+
+    config_entry = create_mock_frigate_config_entry(hass)
+
+    config_entry = await setup_mock_frigate_config_entry(
+        hass, config_entry=config_entry, client=client
+    )
+    await hass.async_block_till_done()
+
+    # Entity: Ensure the entity does not exist.
+    entity_registry = er.async_get(hass)
+    assert not entity_registry.async_get_entity_id(
+        DOMAIN, "sensor", "front_door_amazon_count"
+    )


### PR DESCRIPTION
In Frigate 0.16 logo sub labels have support for the topics required for the integrations sensors to function correctly, this ensures that the support for old frigate versions remains while supporting this on 0.16+