### PR TITLE
fix camera connections

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -309,7 +309,7 @@ class FrigateCamera(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
 
         image_url = str(
             URL(self._url)
@@ -464,7 +464,7 @@ class BirdseyeCamera(FrigateEntity, Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
 
         image_url = str(
             URL(self._url)
@@ -488,7 +488,7 @@ class FrigateCameraWebRTC(FrigateCamera):
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
         """Handle the WebRTC offer and return an answer."""
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
         url = f"{self._url}/api/go2rtc/webrtc?src={self._cam_name}"
         payload = {"type": "offer", "sdp": offer_sdp}
         async with websession.post(url, json=payload) as resp:
@@ -507,7 +507,7 @@ class BirdseyeCameraWebRTC(BirdseyeCamera):
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
         """Handle the WebRTC offer and return an answer."""
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
         url = f"{self._url}/api/go2rtc/webrtc?src={self._cam_name}"
         payload = {"type": "offer", "sdp": offer_sdp}
         async with websession.post(url, json=payload) as resp:

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -309,7 +309,9 @@ class FrigateCamera(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
+        websession = async_get_clientsession(
+            self.hass, verify_ssl=self._client.validate_ssl
+        )
 
         image_url = str(
             URL(self._url)
@@ -464,7 +466,9 @@ class BirdseyeCamera(FrigateEntity, Camera):
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
+        websession = async_get_clientsession(
+            self.hass, verify_ssl=self._client.validate_ssl
+        )
 
         image_url = str(
             URL(self._url)
@@ -488,7 +492,9 @@ class FrigateCameraWebRTC(FrigateCamera):
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
         """Handle the WebRTC offer and return an answer."""
-        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
+        websession = async_get_clientsession(
+            self.hass, verify_ssl=self._client.validate_ssl
+        )
         url = f"{self._url}/api/go2rtc/webrtc?src={self._cam_name}"
         payload = {"type": "offer", "sdp": offer_sdp}
         async with websession.post(url, json=payload) as resp:
@@ -507,7 +513,9 @@ class BirdseyeCameraWebRTC(BirdseyeCamera):
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage
     ) -> None:
         """Handle the WebRTC offer and return an answer."""
-        websession = async_get_clientsession(self.hass, verify_ssl=self._client.validate_ssl)
+        websession = async_get_clientsession(
+            self.hass, verify_ssl=self._client.validate_ssl
+        )
         url = f"{self._url}/api/go2rtc/webrtc?src={self._cam_name}"
         payload = {"type": "offer", "sdp": offer_sdp}
         async with websession.post(url, json=payload) as resp:


### PR DESCRIPTION
As reported by @RamblinWreck77 in https://github.com/blakeblackshear/frigate-hass-integration/issues/808

Looks like the camera.py file uses a home assistant core helper function to create websession connections:

https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/aiohttp_client.py
check lines 113 and 115

 it accepts an argument for verify_ssl so i think it can be fixed with these changes, would love a second opinion.

cheers.
nick.