### PR TITLE
Migrate Tests to FlowResultType

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 env:
-  DEFAULT_PYTHON: "3.12"
+  DEFAULT_PYTHON: "3.13"
 
 jobs:
   pre-commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ addopts = "--timeout=10 --cov-report=xml:coverage.xml --cov-report=term-missing 
 [tool.mypy]
 # Stock HomeAssistant mypy configuration.
 ignore_missing_imports = true
-python_version = "3.12"
+python_version = "3.13"
 follow_imports = "silent"
 strict_equality = true
 warn_incomplete_stub = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 aiohttp_cors
 attr
 janus
-homeassistant==2024.12.0
+homeassistant==2025.4.1
 paho-mqtt
 python-dateutil
 yarl

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ flake8
 mypy
 pre-commit
 pytest
-pytest-homeassistant-custom-component==0.13.190
+pytest-homeassistant-custom-component==0.13.233
 pylint-pytest
 pylint
 pytest-aiohttp

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,9 +16,10 @@ from custom_components.frigate.const import (
     CONF_RTSP_URL_TEMPLATE,
     DOMAIN,
 )
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from . import (
     TEST_PASSWORD,
@@ -240,7 +241,7 @@ async def test_duplicate(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -273,7 +274,7 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
             },
         )
         await hass.async_block_till_done()
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_ENABLE_WEBRTC] is True
         assert result["data"][CONF_RTSP_URL_TEMPLATE] == "http://moo"
         assert result["data"][CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS] == 60
@@ -300,5 +301,5 @@ async def test_options(hass: HomeAssistant) -> None:
             config_entry.entry_id,
         )
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "only_advanced_options"


### PR DESCRIPTION
The data entry flow constants have been deprecated since 2022.7.0 and
were finally removed in 2025.1.0

Updates the tests to homeassistant 2025.4.1.

Fixes: #860