### PR TITLE
Fix views to work with auth endpoint

### DIFF
--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -311,7 +311,7 @@ class FrigateApiClient:
         if current_time >= self._token_data["expires"]:  # Compare UTC-aware datetimes
             await self._get_token()
 
-    async def _get_auth_headers(self) -> dict[str, str]:
+    async def get_auth_headers(self) -> dict[str, str]:
         """
         Get headers for API requests, including the JWT token if available.
         Ensures that the token is refreshed if needed.
@@ -342,7 +342,7 @@ class FrigateApiClient:
             headers = {}
 
         if not is_login_request:
-            headers.update(await self._get_auth_headers())
+            headers.update(await self.get_auth_headers())
 
         try:
             async with async_timeout.timeout(TIMEOUT):

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -356,7 +356,7 @@ class FrigateCamera(
             % ({"h": height} if height is not None and height > 0 else {})
         )
 
-        headers = await self._client._get_auth_headers()
+        headers = await self._client.get_auth_headers()
         async with async_timeout.timeout(10):
             response = await websession.get(image_url, headers=headers)
             return await response.read()
@@ -536,7 +536,7 @@ class BirdseyeCamera(FrigateEntity, Camera):
             % ({"h": height} if height is not None and height > 0 else {})
         )
 
-        headers = await self._client._get_auth_headers()
+        headers = await self._client.get_auth_headers()
         async with async_timeout.timeout(10):
             response = await websession.get(image_url, headers=headers)
             return await response.read()
@@ -558,7 +558,7 @@ class FrigateCameraWebRTC(FrigateCamera):
         )
         url = f"{self._url}/api/go2rtc/webrtc?src={self._cam_name}"
         payload = {"type": "offer", "sdp": offer_sdp}
-        headers = await self._client._get_auth_headers()
+        headers = await self._client.get_auth_headers()
         async with websession.post(url, json=payload, headers=headers) as resp:
             answer = await resp.json()
             send_message(WebRTCAnswer(answer["sdp"]))
@@ -580,7 +580,7 @@ class BirdseyeCameraWebRTC(BirdseyeCamera):
         )
         url = f"{self._url}/api/go2rtc/webrtc?src={self._cam_name}"
         payload = {"type": "offer", "sdp": offer_sdp}
-        headers = await self._client._get_auth_headers()
+        headers = await self._client.get_auth_headers()
         async with websession.post(url, json=payload, headers=headers) as resp:
             answer = await resp.json()
             send_message(WebRTCAnswer(answer["sdp"]))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -510,7 +510,7 @@ async def test_refresh_token_if_needed_with_expires(
 async def test_get_auth_headers(
     aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
 ) -> None:
-    """Test _get_auth_headers includes Authorization header with valid token."""
+    """Test get_auth_headers includes Authorization header with valid token."""
     token = get_test_token()
 
     async def login_handler(request: web.Request) -> web.Response:
@@ -527,7 +527,7 @@ async def test_get_auth_headers(
     )
     # Pre-fetch token
     await frigate_client._get_token()
-    headers = await frigate_client._get_auth_headers()
+    headers = await frigate_client.get_auth_headers()
 
     assert headers["Authorization"] == f"Bearer {token}"
 


### PR DESCRIPTION
Tried to also add some refactoring changes to api.py and camera.py (I was originally trying to fix the auth issue there as well, which I did, but it was found in parallel https://github.com/blakeblackshear/frigate/discussions/18278

I would still push the minor refactor, and will maybe in the future, but I couldn't get a proper local setup going, since those changes will require more tests. I'm hoping these changes are okay since they are just adding the header. I'll be busy for the next little while so thought it'd be good to try to get this in.

Changes:
- Renamed the "_get_auth_headers" method, removing the "_" since it is not a private method anymore
- Added function to the view mixin to include the ability to grab the auth headers and add it to kwargs
- Use above function to add kwargs headers in overriden GET method
- Use kwargs in proxiedURL