### PR TITLE
feat(sensor): refactor sensors for long-term statistics support

### DIFF
--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -14,12 +14,18 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfSoundPressure,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 
 from . import (
     FrigateDataUpdateCoordinator,
@@ -136,10 +142,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class FrigateFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]):
+class FrigateFpsSensor(
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
+):
     """Frigate Sensor class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_name = "Detection fps"
 
     def __init__(
@@ -169,8 +178,8 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordin
         }
 
     @property
-    def state(self) -> int | None:
-        """Return the state of the sensor."""
+    def native_value(self) -> int | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = self.coordinator.data.get("detection_fps")
             if data is not None:
@@ -181,8 +190,8 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordin
         return None
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
         return FPS
 
     @property
@@ -192,7 +201,7 @@ class FrigateFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordin
 
 
 class FrigateStatusSensor(
-    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
 ):
     """Frigate Status Sensor class."""
 
@@ -226,8 +235,8 @@ class FrigateStatusSensor(
         }
 
     @property
-    def state(self) -> str:
-        """Return the state of the sensor."""
+    def native_value(self) -> str:
+        """Return the value of the sensor."""
         return str(self.coordinator.server_status)
 
     @property
@@ -237,11 +246,13 @@ class FrigateStatusSensor(
 
 
 class FrigateUptimeSensor(
-    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
 ):
     """Frigate Uptime Sensor class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.DURATION
     _attr_name = "Uptime"
 
     def __init__(
@@ -271,8 +282,8 @@ class FrigateUptimeSensor(
         }
 
     @property
-    def state(self) -> int | None:
-        """Return the state of the sensor."""
+    def native_value(self) -> int | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = self.coordinator.data.get("service", {}).get("uptime", 0)
             try:
@@ -282,9 +293,9 @@ class FrigateUptimeSensor(
         return None
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
-        return S
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
+        return UnitOfTime.SECONDS
 
     @property
     def icon(self) -> str:
@@ -293,11 +304,13 @@ class FrigateUptimeSensor(
 
 
 class DetectorSpeedSensor(
-    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
 ):
     """Frigate Detector Speed class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.DURATION
 
     def __init__(
         self,
@@ -335,8 +348,8 @@ class DetectorSpeedSensor(
         return f"{get_friendly_name(self._detector_name)} inference speed"
 
     @property
-    def state(self) -> int | None:
-        """Return the state of the sensor."""
+    def native_value(self) -> int | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = (
                 self.coordinator.data.get("detectors", {})
@@ -351,8 +364,8 @@ class DetectorSpeedSensor(
         return None
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
         return MS
 
     @property
@@ -361,10 +374,13 @@ class DetectorSpeedSensor(
         return ICON_SPEEDOMETER
 
 
-class GpuLoadSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]):
+class GpuLoadSensor(
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
+):
     """Frigate GPU Load class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -398,8 +414,8 @@ class GpuLoadSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinato
         }
 
     @property
-    def state(self) -> float | None:
-        """Return the state of the sensor."""
+    def native_value(self) -> float | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = (
                 self.coordinator.data.get("gpu_usages", {})
@@ -418,9 +434,9 @@ class GpuLoadSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinato
         return None
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
-        return "%"
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
+        return PERCENTAGE
 
     @property
     def icon(self) -> str:
@@ -428,10 +444,13 @@ class GpuLoadSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinato
         return ICON_SPEEDOMETER
 
 
-class CameraFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]):
+class CameraFpsSensor(
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
+):
     """Frigate Camera Fps class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -476,21 +495,19 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordina
         return f"{self._fps_type} fps"
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
         return FPS
 
     @property
-    def state(self) -> int | None:
-        """Return the state of the sensor."""
-
+    def native_value(self) -> int | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = (
                 self.coordinator.data.get("cameras", {})
                 .get(self._cam_name, {})
                 .get(f"{self._fps_type}_fps")
             )
-
             if data is not None:
                 try:
                     return round(float(data))
@@ -504,8 +521,13 @@ class CameraFpsSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordina
         return ICON_SPEEDOMETER
 
 
-class CameraSoundSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]):
+class CameraSoundSensor(
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
+):
     """Frigate Camera Sound Level class."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.SOUND_PRESSURE
 
     def __init__(
         self,
@@ -548,21 +570,19 @@ class CameraSoundSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordi
         return "sound level"
 
     @property
-    def unit_of_measurement(self) -> Any:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> Any:
+        """Return the native unit of measurement of the sensor."""
         return UnitOfSoundPressure.DECIBEL
 
     @property
-    def state(self) -> int | None:
-        """Return the state of the sensor."""
-
+    def native_value(self) -> int | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = (
                 self.coordinator.data.get("cameras", {})
                 .get(self._cam_name, {})
                 .get("audio_dBFS")
             )
-
             if data is not None:
                 try:
                     return round(float(data))
@@ -576,8 +596,10 @@ class CameraSoundSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordi
         return ICON_WAVEFORM
 
 
-class FrigateObjectCountSensor(FrigateMQTTEntity):
+class FrigateObjectCountSensor(FrigateMQTTEntity, SensorEntity):
     """Frigate Motion Sensor class."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -647,13 +669,13 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
         return f"{get_friendly_name(self._obj_name)} count"
 
     @property
-    def state(self) -> int:
-        """Return true if the binary sensor is on."""
+    def native_value(self) -> int:
+        """Return the value of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
         return "objects"
 
     @property
@@ -662,8 +684,10 @@ class FrigateObjectCountSensor(FrigateMQTTEntity):
         return self._icon
 
 
-class FrigateActiveObjectCountSensor(FrigateMQTTEntity):
+class FrigateActiveObjectCountSensor(FrigateMQTTEntity, SensorEntity):
     """Frigate Motion Sensor class."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -734,13 +758,13 @@ class FrigateActiveObjectCountSensor(FrigateMQTTEntity):
         return f"{get_friendly_name(self._obj_name)} active count".title()
 
     @property
-    def state(self) -> int:
-        """Return true if the binary sensor is on."""
+    def native_value(self) -> int:
+        """Return the value of the sensor."""
         return self._state
 
     @property
-    def unit_of_measurement(self) -> str:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> str:
+        """Return the native unit of measurement of the sensor."""
         return "objects"
 
     @property
@@ -749,10 +773,14 @@ class FrigateActiveObjectCountSensor(FrigateMQTTEntity):
         return self._icon
 
 
-class DeviceTempSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]):
+class DeviceTempSensor(
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
+):
     """Frigate Coral Temperature Sensor class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
 
     def __init__(
         self,
@@ -790,8 +818,8 @@ class DeviceTempSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordin
         return f"{get_friendly_name(self._name)} temperature"
 
     @property
-    def state(self) -> float | None:
-        """Return the state of the sensor."""
+    def native_value(self) -> float | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             data = (
                 self.coordinator.data.get("service", {})
@@ -805,8 +833,8 @@ class DeviceTempSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordin
         return None
 
     @property
-    def unit_of_measurement(self) -> Any:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> Any:
+        """Return the native unit of measurement of the sensor."""
         return UnitOfTemperature.CELSIUS
 
     @property
@@ -816,11 +844,12 @@ class DeviceTempSensor(FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordin
 
 
 class CameraProcessCpuSensor(
-    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator]
+    FrigateEntity, CoordinatorEntity[FrigateDataUpdateCoordinator], SensorEntity
 ):
     """Cpu usage for camera processes class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -861,8 +890,8 @@ class CameraProcessCpuSensor(
         }
 
     @property
-    def state(self) -> float | None:
-        """Return the state of the sensor."""
+    def native_value(self) -> float | None:
+        """Return the value of the sensor."""
         if self.coordinator.data:
             pid_key = (
                 "pid" if self._process_type == "detect" else f"{self._process_type}_pid"
@@ -887,8 +916,8 @@ class CameraProcessCpuSensor(
         return None
 
     @property
-    def unit_of_measurement(self) -> Any:
-        """Return the unit of measurement of the sensor."""
+    def native_unit_of_measurement(self) -> Any:
+        """Return the native unit of measurement of the sensor."""
         return PERCENTAGE
 
     @property
@@ -897,7 +926,7 @@ class CameraProcessCpuSensor(
         return ICON_CORAL
 
 
-class FrigateRecognizedFaceSensor(FrigateMQTTEntity):
+class FrigateRecognizedFaceSensor(FrigateMQTTEntity, SensorEntity):
     """Frigate Recognized Face Sensor class."""
 
     def __init__(
@@ -990,8 +1019,8 @@ class FrigateRecognizedFaceSensor(FrigateMQTTEntity):
         return "Last Recognized Face"
 
     @property
-    def state(self) -> str:
-        """Return true if the binary sensor is on."""
+    def native_value(self) -> str:
+        """Return the value of the sensor."""
         return str(self._state).title()
 
     @property
@@ -1000,7 +1029,7 @@ class FrigateRecognizedFaceSensor(FrigateMQTTEntity):
         return ICON_FACE
 
 
-class FrigateRecognizedPlateSensor(FrigateMQTTEntity):
+class FrigateRecognizedPlateSensor(FrigateMQTTEntity, SensorEntity):
     """Frigate Recognized License Plate Sensor class."""
 
     def __init__(
@@ -1096,8 +1125,8 @@ class FrigateRecognizedPlateSensor(FrigateMQTTEntity):
         return "Last Recognized Plate"
 
     @property
-    def state(self) -> str:
-        """Return true if the binary sensor is on."""
+    def native_value(self) -> str:
+        """Return the value of the sensor."""
         return self._state
 
     @property


### PR DESCRIPTION
### feat(sensor): refactor sensors for long-term statistics support

- Update all sensor classes to inherit from `SensorEntity` for proper integration with Home Assistant's sensor platform.
- Replace `@property def state(self)` with `@property def native_value(self)` to align with modern HA sensor API and enable statistics generation.
- Set `native_unit_of_measurement` consistently.
- Ensure numeric sensors (e.g., FPS, CPU, object counts) are positioned for measurement-based statistics.

<img width="978" height="811" alt="image" src="https://github.com/user-attachments/assets/b8e39690-1d10-4480-b1f0-cafce4c2ce4e" />
