### PR TITLE
Implementation of ssl validation ignore for views

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -207,20 +207,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    ws_api_async_setup(hass)
-    views_async_setup(hass)
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
+    validate_ssl = bool(entry.data.get("validate_ssl"))
+
     client = FrigateApiClient(
         str(entry.data.get(CONF_URL)),
         async_get_clientsession(hass),
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
-        bool(entry.data.get("validate_ssl")),
+        validate_ssl,
     )
+
+    ws_api_async_setup(hass)
+    views_async_setup(hass, validate_ssl)
+
     coordinator = FrigateDataUpdateCoordinator(hass, client=client)
     await coordinator.async_config_entry_first_refresh()
 


### PR DESCRIPTION
After switch to https only i have a problem with ssl. HA cards are working but i have problem with notifications as gifs and miniatures were not accessible due to ssl error during communication from HA to frigate. Exactly the same error as here https://github.com/blakeblackshear/frigate-hass-integration/issues/900, I was able to fix it with following changes.