### PR TITLE
Use event start / end time to get clip path so it can have padding added

### DIFF
--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -67,6 +67,21 @@ class FrigateApiClient:
             await self.api_wrapper("get", str(URL(self._host) / "api/stats")),
         )
 
+    async def async_get_event(
+        self,
+        event_id: str,
+        decode_json: bool = True,
+    ) -> dict[str, Any]:
+        """Get a single event by ID from the API."""
+        return cast(
+            dict[str, Any],
+            await self.api_wrapper(
+                "get",
+                str(URL(self._host) / f"api/events/{event_id}"),
+                decode_json=decode_json,
+            ),
+        )
+
     async def async_get_events(
         self,
         cameras: list[str] | None = None,

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -63,6 +63,7 @@ CONF_RTMP_URL_TEMPLATE = "rtmp_url_template"
 # Defaults
 DEFAULT_NAME = DOMAIN
 DEFAULT_HOST = "http://ccab4aaf-frigate:5000"
+DEFAULT_VOD_EVENT_PADDING = 5
 
 
 STARTUP_MESSAGE = """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,6 +57,35 @@ async def test_async_get_stats(
     assert stats_in == await frigate_client.async_get_stats()
 
 
+async def test_async_get_event(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test async_get_event."""
+    event_in = {
+        "camera": "front_door",
+        "end_time": 1623643757.837382,
+        "false_positive": False,
+        "has_clip": True,
+        "has_snapshot": False,
+        "id": "1623643750.569992-64ji22",
+        "label": "person",
+        "start_time": 1623643750.569992,
+        "thumbnail": "thumbnail",
+        "data": {"top_score": 0.70703125},
+        "zones": [],
+    }
+    event_id = "1623643750.569992-64ji22"
+    event_handler = AsyncMock(return_value=web.json_response(event_in))
+
+    server = await start_frigate_server(
+        aiohttp_server, [web.get(f"/api/events/{event_id}", event_handler)]
+    )
+
+    frigate_client = FrigateApiClient(str(server.make_url("/")), aiohttp_session)
+    assert event_in == await frigate_client.async_get_event(event_id)
+    assert event_handler.called
+
+
 async def test_async_get_events(
     aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
 ) -> None:

--- a/tests/test_media_source.py
+++ b/tests/test_media_source.py
@@ -18,6 +18,7 @@ from custom_components.frigate.const import (
     ATTR_CLIENT_ID,
     ATTR_MQTT,
     CONF_MEDIA_BROWSER_ENABLE,
+    DEFAULT_VOD_EVENT_PADDING,
     DOMAIN,
 )
 from custom_components.frigate.media_source import (
@@ -628,6 +629,20 @@ async def test_async_resolve_media(
 
     await setup_mock_frigate_config_entry(hass, client=frigate_client)
 
+    # Mock the async_get_event method to return event with timestamps
+    event_start_time = 1234567890
+    event_end_time = 1234567900
+    padding = DEFAULT_VOD_EVENT_PADDING
+
+    frigate_client.async_get_event = AsyncMock(
+        return_value={
+            "id": "CLIP-FOO",
+            "camera": "camera",
+            "start_time": event_start_time,
+            "end_time": event_end_time,
+        }
+    )
+
     # Test resolving a clip.
     media = await media_source.async_resolve_media(
         hass,
@@ -635,7 +650,7 @@ async def test_async_resolve_media(
         target_media_player="media_player.kitchen",
     )
     assert media == PlayMedia(
-        url=f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/vod/event/CLIP-FOO/index.m3u8",
+        url=f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/vod/camera/start/{event_start_time - padding}/end/{event_end_time + padding}/index.m3u8",
         mime_type="application/x-mpegURL",
     )
 


### PR DESCRIPTION
We can't use query parameters to define padding because nginx does not pass these on to the backend. The easiest solution is to use a timestamp based approach by getting the event during the playback request.

fixes https://github.com/blakeblackshear/frigate-hass-integration/issues/946