### PR TITLE
Add switches for Object and Review Descriptions

### DIFF
--- a/custom_components/frigate/icons.py
+++ b/custom_components/frigate/icons.py
@@ -3,6 +3,7 @@
 ICON_AUDIO = "mdi:ear-hearing"
 ICON_AUDIO_OFF = "mdi:ear-hearing-off"
 ICON_PTZ_AUTOTRACKER = "mdi:cctv"
+ICON_DESCRIPTIONS = "mdi:text-box-check"
 ICON_BICYCLE = "mdi:bicycle"
 ICON_CAR = "mdi:car"
 ICON_CAT = "mdi:cat"
@@ -56,6 +57,8 @@ def get_icon_from_switch(switch_type: str) -> str:
         return ICON_AUDIO
     if switch_type == "ptz_autotracker":
         return ICON_PTZ_AUTOTRACKER
+    if switch_type == "object_descriptions" or switch_type == "review_descriptions":
+        return ICON_DESCRIPTIONS
 
     return ICON_MOTION_SENSOR
 

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -20,6 +20,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    verify_frigate_version,
 )
 from .const import ATTR_CONFIG, DOMAIN, NAME
 from .icons import get_icon_from_switch
@@ -71,6 +72,27 @@ async def async_setup_entry(
                     True,
                     "ptz_autotracker",
                 ),
+            )
+
+        # GenAI switches require Frigate 0.17+
+        if verify_frigate_version(frigate_config, "0.17"):
+            entities.extend(
+                [
+                    FrigateSwitch(
+                        entry,
+                        frigate_config,
+                        camera,
+                        "object_descriptions",
+                        False,
+                    ),
+                    FrigateSwitch(
+                        entry,
+                        frigate_config,
+                        camera,
+                        "review_descriptions",
+                        False,
+                    ),
+                ]
             )
 
     async_add_entities(entities)


### PR DESCRIPTION
This PR adds switches to control the creation of object and review summaries in Frigate using GenAI