### PR TITLE
Fix image entity using naive datetime causing wrong timezone display

### DIFF
--- a/custom_components/frigate/image.py
+++ b/custom_components/frigate/image.py
@@ -81,7 +81,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, ImageEntity):
     def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
         if isinstance(msg.payload, bytes):
-            self._last_image_timestamp = datetime.datetime.now()
+            self._last_image_timestamp = datetime.datetime.now(datetime.timezone.utc)
             self._last_image = msg.payload
             self.async_write_ha_state()
 


### PR DESCRIPTION
## Summary

`datetime.datetime.now()` returns a naive datetime (no timezone info). Home Assistant treats naive datetimes as UTC when rendering, so the Person (and other object) image entities display timestamps in UTC instead of the user's configured timezone.

## Fix

Use `datetime.datetime.now(datetime.timezone.utc)` to make it timezone-aware so HA correctly converts it for display.

Fixes #1052