### PR TITLE
Route go2rtc API proxy through safe Frigate endpoints

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -563,18 +563,6 @@ class Go2RTCAPIBaseProxyView(FrigateProxyViewMixin):
         config = hass.data[DOMAIN].get(config_entry.entry_id, {}).get(ATTR_CONFIG, {})
         return verify_frigate_version(config, "0.18") if config else False
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
-        """Create proxied URL."""
-        return ProxiedURL(
-            url=self._get_fqdn_path(
-                request,
-                f"api/go2rtc/{kwargs['path']}",
-                frigate_instance_id=kwargs.get("frigate_instance_id"),
-            ),
-            headers=kwargs["headers"],
-            query_params=self._get_query_params(request),
-        )
-
 
 class Go2RTCAPIWebsocketProxyView(Go2RTCAPIBaseProxyView, FrigateWebsocketProxyView):
     """A proxy for go2rtc API (websocket)."""

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -547,6 +547,22 @@ class WebRTCProxyView(FrigateWebsocketProxyView):
 class Go2RTCAPIBaseProxyView(FrigateProxyViewMixin):
     """A base class for go2rtc proxy views."""
 
+    def _is_frigate_018_or_later(
+        self, request: web.Request, frigate_instance_id: str | None = None
+    ) -> bool:
+        """Check if the Frigate instance is version 0.18+."""
+        # Import here to avoid circular import (views is imported by __init__)
+        from custom_components.frigate import verify_frigate_version
+
+        hass = request.app[KEY_HASS]
+        config_entry = self._get_config_entry_for_request(
+            request, frigate_instance_id=frigate_instance_id
+        )
+        if not config_entry:
+            return False
+        config = hass.data[DOMAIN].get(config_entry.entry_id, {}).get(ATTR_CONFIG, {})
+        return verify_frigate_version(config, "0.18") if config else False
+
     def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
@@ -568,6 +584,27 @@ class Go2RTCAPIWebsocketProxyView(Go2RTCAPIBaseProxyView, FrigateWebsocketProxyV
 
     name = "api:frigate:go2rtc:ws"
 
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        frigate_instance_id = kwargs.get("frigate_instance_id")
+
+        # Frigate 0.18+ removed the /api/go2rtc/api nginx block;
+        # route through the existing /live/mse nginx path instead.
+        if self._is_frigate_018_or_later(request, frigate_instance_id):
+            upstream_path = f"live/mse/{kwargs['path']}"
+        else:
+            upstream_path = f"api/go2rtc/{kwargs['path']}"
+
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                upstream_path,
+                frigate_instance_id=frigate_instance_id,
+            ),
+            headers=kwargs["headers"],
+            query_params=self._get_query_params(request),
+        )
+
 
 class Go2RTCAPIProxyView(Go2RTCAPIBaseProxyView, FrigateProxyView):
     """A proxy for go2rtc API (http)."""
@@ -576,3 +613,32 @@ class Go2RTCAPIProxyView(Go2RTCAPIBaseProxyView, FrigateProxyView):
     extra_urls = ["/api/frigate/go2rtc/{path:.*}"]
 
     name = "api:frigate:go2rtc"
+
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Create proxied URL."""
+        path = kwargs["path"]
+        frigate_instance_id = kwargs.get("frigate_instance_id")
+
+        # Frigate 0.18+ removed the /api/go2rtc/api nginx block;
+        # route streams through Frigate's Python API which masks credentials.
+        if (
+            self._is_frigate_018_or_later(request, frigate_instance_id)
+            and path.rstrip("/") == "api/streams"
+        ):
+            src = request.query.get("src", "")
+            if src:
+                upstream_path = f"api/go2rtc/streams/{src}"
+            else:
+                upstream_path = "api/go2rtc/streams"
+        else:
+            upstream_path = f"api/go2rtc/{path}"
+
+        return ProxiedURL(
+            url=self._get_fqdn_path(
+                request,
+                upstream_path,
+                frigate_instance_id=frigate_instance_id,
+            ),
+            headers=kwargs["headers"],
+            query_params=self._get_query_params(request),
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -83,8 +83,9 @@ async def local_frigate(hass: HomeAssistant, aiohttp_server: Any) -> Any:
             web.get("/live/mse/querystring", ws_response_handler),
             web.get("/live/webrtc/front_door", ws_response_handler),
             web.get("/live/webrtc/querystring", ws_response_handler),
-            web.get("/api/go2rtc/api/streams", response_handler),
-            web.get("/api/go2rtc/api/ws", ws_response_handler),
+            web.get("/api/go2rtc/streams", response_handler),
+            web.get("/api/go2rtc/streams/front_door", response_handler),
+            web.get("/live/mse/api/ws", ws_response_handler),
             web.get(
                 "/api/front_door/start/1664067600.02/end/1664068200.03/clip.mp4",
                 response_handler,
@@ -810,7 +811,7 @@ async def test_go2rtc_api_ws_proxy_view(
     ) as ws:
         # First message from the fixture will be the URL and headers.
         request = await ws.receive_json()
-        assert request["url"].endswith("/api/go2rtc/api/ws")
+        assert request["url"].endswith("/live/mse/api/ws")
 
         # Subsequent messages will echo back.
         await ws.send_str("Hello!")
@@ -825,8 +826,16 @@ async def test_go2rtc_api_proxy_view(
 
     authenticated_hass_client = await hass_client()
 
+    # Test streams endpoint routes to Frigate's safe API (credentials masked)
     resp = await authenticated_hass_client.get(
         f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/go2rtc/api/streams"
+    )
+    assert resp.status == HTTPStatus.OK
+
+    # Test streams endpoint with src query param routes to per-stream API
+    resp = await authenticated_hass_client.get(
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/go2rtc/api/streams",
+        params={"src": "front_door"},
     )
     assert resp.status == HTTPStatus.OK
 
@@ -839,6 +848,67 @@ async def test_go2rtc_api_proxy_view(
         "/api/frigate/NOT_A_REAL_ID/go2rtc/api/streams"
     )
     assert resp.status == HTTPStatus.NOT_FOUND
+
+
+@pytest.fixture
+async def local_frigate_017(hass: HomeAssistant, aiohttp_server: Any) -> Any:
+    """Point the integration at a local fake Frigate server running pre-0.18."""
+
+    server = await start_frigate_server(
+        aiohttp_server,
+        [
+            web.get("/api/go2rtc/api/streams", response_handler),
+            web.get("/api/go2rtc/api/ws", ws_response_handler),
+        ],
+    )
+
+    config_017 = copy.deepcopy(TEST_CONFIG)
+    config_017["version"] = "0.17-0"
+
+    client = create_mock_frigate_client()
+    client.async_get_config = AsyncMock(return_value=config_017)
+    client.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
+    config_entry = create_mock_frigate_config_entry(
+        hass, data={CONF_URL: str(server.make_url("/"))}
+    )
+    await setup_mock_frigate_config_entry(
+        hass, config_entry=config_entry, client=client
+    )
+    LocalFrigate = namedtuple("LocalFrigate", ["server", "client", "config_entry"])
+    return LocalFrigate(server, client, config_entry)
+
+
+async def test_go2rtc_api_ws_proxy_view_pre_018(
+    hass: Any,
+    local_frigate_017: Any,
+    hass_client: Any,
+) -> None:
+    """Test Go2RTC API websocket uses old path on pre-0.18 Frigate."""
+
+    authenticated_hass_client = await hass_client()
+
+    async with authenticated_hass_client.ws_connect(
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/go2rtc/ws/api/ws"
+    ) as ws:
+        request = await ws.receive_json()
+        assert request["url"].endswith("/api/go2rtc/api/ws")
+
+        await ws.send_str("Hello!")
+        assert (await ws.receive_str()) == "Hello!"
+
+
+async def test_go2rtc_api_proxy_view_pre_018(
+    local_frigate_017: Any,
+    hass_client: Any,
+) -> None:
+    """Test Go2RTC API HTTP uses old path on pre-0.18 Frigate."""
+
+    authenticated_hass_client = await hass_client()
+
+    resp = await authenticated_hass_client.get(
+        f"/api/frigate/{TEST_FRIGATE_INSTANCE_ID}/go2rtc/api/streams"
+    )
+    assert resp.status == HTTPStatus.OK
 
 
 async def test_review_clips_proxy_view(


### PR DESCRIPTION
Route go2rtc API proxy through Frigate's credential-masking Python API (`api/go2rtc/streams`) and existing `live/mse` nginx path on 0.18+, where the raw `/api/go2rtc/api` nginx block was removed in https://github.com/blakeblackshear/frigate/pull/22735

Falls back to the original `api/go2rtc/{path}` routing for pre-0.18 Frigate instances using a version check.