### PR TITLE
Fix dev container initialization and Frigate test stream on newer versions

### DIFF
--- a/.devcontainer/scripts/devcontainer_initialize.sh
+++ b/.devcontainer/scripts/devcontainer_initialize.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-# Ensure there is no leftover from previous run
-docker compose down --remove-orphans --volumes
-
 # Add LOCAL_WORKSPACE_FOLDER to .env file
 readonly wanted_line_key="LOCAL_WORKSPACE_FOLDER"
 readonly wanted_line="${wanted_line_key}='${PWD}'"
@@ -15,5 +12,8 @@ if [[ -f "${file}" ]] && grep -q "^${wanted_line_key}=" "${file}"; then
 else
     echo "${wanted_line}" >>"${file}"
 fi
+
+# Ensure there is no leftover from previous run
+docker compose down --remove-orphans --volumes
 
 echo "$0 finished." >&2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - .devcontainer/frigate_media:/media/frigate
       # Avoid mounting the entire config directory so that data is not persisted
       - .devcontainer/frigate_config/config.yml:/config/config.yml:ro
+    environment:
+      - GO2RTC_ALLOW_ARBITRARY_EXEC=true
   mqtt:
     image: eclipse-mosquitto:2
     restart: unless-stopped


### PR DESCRIPTION
* Fix `devcontainer_initialize.sh` failing if `.env` isn't previously created due to `docker compose down` executing before checks, causing an empty volume path.
* Fix test stream not loading in newer Frigate versions due to `exec` default block.