### PR TITLE
Drop user_prompt from LLMContext invocaction

### DIFF
--- a/tests/test_llm_functions.py
+++ b/tests/test_llm_functions.py
@@ -28,7 +28,6 @@ def _create_llm_context() -> llm.LLMContext:
         language="en",
         assistant=None,
         device_id=None,
-        user_prompt=None,
     )
 
 


### PR DESCRIPTION
Dropped in 2025.5.3.

Ref: home-assistant/core@059c12798de2c7b0f285cb79e60c01f4be231701