### PR TITLE
fix: Proxy views should respect `validate_ssl` option

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -63,6 +63,7 @@ from .const import (
     ATTR_WS_REVIEW_PROXY,
     CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_RTMP_URL_TEMPLATE,
+    CONF_VALIDATE_SSL,
     DOMAIN,
     FRIGATE_RELEASES_URL,
     FRIGATE_VERSION_ERROR_CUTOFF,
@@ -292,7 +293,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async_get_clientsession(hass),
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
-        bool(entry.data.get("validate_ssl")),
+        entry.data.get(CONF_VALIDATE_SSL, True),
     )
     coordinator = FrigateDataUpdateCoordinator(hass, client=client)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     CONF_RTSP_URL_TEMPLATE,
+    CONF_VALIDATE_SSL,
     DEFAULT_HOST,
     DOMAIN,
 )
@@ -83,7 +84,7 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 session,
                 user_input.get(CONF_USERNAME),
                 user_input.get(CONF_PASSWORD),
-                bool(user_input.get("validate_ssl")),
+                user_input.get(CONF_VALIDATE_SSL, True),
             )
             await client.async_get_stats()
         except FrigateApiClientError:
@@ -123,7 +124,8 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_URL, default=user_input.get(CONF_URL, DEFAULT_HOST)
                     ): str,
                     vol.Required(
-                        "validate_ssl", default=user_input.get("validate_ssl", True)
+                        CONF_VALIDATE_SSL,
+                        default=user_input.get(CONF_VALIDATE_SSL, True),
                     ): bool,
                     vol.Optional(
                         CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -51,6 +51,7 @@ ATTR_INCLUDE_RECORDING = "include_recording"
 ATTR_NAME = "name"
 
 # Configuration and options
+CONF_VALIDATE_SSL = "validate_ssl"
 CONF_MEDIA_BROWSER_ENABLE = "media_browser_enable"
 CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS = "notification_proxy_expire_after_seconds"

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -156,7 +156,7 @@ class FrigateProxyViewMixin:
                     ctx = ssl.create_default_context()
                     ctx.check_hostname = False
                     ctx.verify_mode = ssl.CERT_NONE
-                    return cast(ProxiedURL, dataclasses.replace(result, ssl_context=ctx))
+                    return dataclasses.replace(result, ssl_context=ctx)
                 return result
 
             return _wrapped

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -30,6 +30,7 @@ from custom_components.frigate.const import (
     ATTR_MQTT,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
+    CONF_VALIDATE_SSL,
     DOMAIN,
 )
 from homeassistant.components.http import KEY_AUTHENTICATED
@@ -144,7 +145,7 @@ class FrigateProxyViewMixin:
         config_entry = self._get_config_entry_for_request(
             request, kwargs.get("frigate_instance_id")
         )
-        if config_entry and not config_entry.data.get("validate_ssl", True):
+        if config_entry and not config_entry.data.get(CONF_VALIDATE_SSL, True):
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -136,32 +136,25 @@ def async_setup(hass: HomeAssistant) -> None:
 class FrigateProxyViewMixin:
     """A mixin for proxying Frigate."""
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Wrap _get_proxied_url in subclasses to inject SSL context from config entry."""
-        super().__init_subclass__(**kwargs)
-        if "_get_proxied_url" not in cls.__dict__:
-            return
+    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        """Get proxied URL with SSL context applied."""
+        result: ProxiedURL = self._get_proxied_url_impl(request, **kwargs)
+        if result.ssl_context is not None:
+            return result
+        config_entry = self._get_config_entry_for_request(
+            request, kwargs.get("frigate_instance_id")
+        )
+        if config_entry and not config_entry.data.get("validate_ssl", True):
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            return dataclasses.replace(result, ssl_context=ctx)
+        return result
 
-        original = cls.__dict__["_get_proxied_url"]
-
-        def _make_wrapped(orig: Any) -> Any:
-            def _wrapped(self: Any, request: web.Request, **kw: Any) -> ProxiedURL:
-                result: ProxiedURL = orig(self, request, **kw)
-                if result.ssl_context is not None:
-                    return result
-                config_entry = self._get_config_entry_for_request(
-                    request, kw.get("frigate_instance_id")
-                )
-                if config_entry and not config_entry.data.get("validate_ssl", True):
-                    ctx = ssl.create_default_context()
-                    ctx.check_hostname = False
-                    ctx.verify_mode = ssl.CERT_NONE
-                    return dataclasses.replace(result, ssl_context=ctx)
-                return result
-
-            return _wrapped
-
-        setattr(cls, "_get_proxied_url", _make_wrapped(original))
+    def _get_proxied_url_impl(
+        self, request: web.Request, **kwargs: Any
+    ) -> ProxiedURL:  # pragma: no cover
+        raise NotImplementedError
 
     def _get_query_params(self, request: web.Request) -> Mapping[str, str]:
         """Get the query params to send upstream."""
@@ -236,7 +229,7 @@ class SnapshotsProxyView(FrigateProxyView):
 
     name = "api:frigate:snapshots"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -259,7 +252,7 @@ class RecordingProxyView(FrigateProxyView):
 
     name = "api:frigate:recording"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -280,7 +273,7 @@ class ThumbnailsProxyView(FrigateProxyView):
 
     name = "api:frigate:thumbnails"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -304,7 +297,7 @@ class ReviewClipsProxyView(FrigateProxyView):
 
     name = "api:frigate:clips"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -325,7 +318,7 @@ class NotificationsProxyView(FrigateProxyView):
 
     name = "api:frigate:notification"
 
-    def _get_proxied_url(
+    def _get_proxied_url_impl(
         self,
         request: web.Request,
         **kwargs: Any,
@@ -442,7 +435,7 @@ class VodProxyView(FrigateProxyView):
         """Get the query params to send upstream."""
         return request.query
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -463,7 +456,7 @@ class VodSegmentProxyView(FrigateProxyView):
 
     name = "api:frigate:vod:segment"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         if not self._async_validate_signed_manifest(request):
             raise HASSWebProxyLibUnauthorizedRequestError()
@@ -514,7 +507,7 @@ class JSMPEGProxyView(FrigateWebsocketProxyView):
 
     name = "api:frigate:jsmpeg"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -539,7 +532,7 @@ class MSEProxyView(FrigateWebsocketProxyView):
 
     name = "api:frigate:mse"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -560,7 +553,7 @@ class WebRTCProxyView(FrigateWebsocketProxyView):
 
     name = "api:frigate:webrtc"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         return ProxiedURL(
             url=self._get_fqdn_path(
@@ -601,7 +594,7 @@ class Go2RTCAPIWebsocketProxyView(Go2RTCAPIBaseProxyView, FrigateWebsocketProxyV
 
     name = "api:frigate:go2rtc:ws"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         frigate_instance_id = kwargs.get("frigate_instance_id")
 
@@ -631,7 +624,7 @@ class Go2RTCAPIProxyView(Go2RTCAPIBaseProxyView, FrigateProxyView):
 
     name = "api:frigate:go2rtc"
 
-    def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+    def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
         path = kwargs["path"]
         frigate_instance_id = kwargs.get("frigate_instance_id")

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import dataclasses
 import datetime
 import logging
 import os
+import ssl
 from typing import Any, Optional, cast
 
 from aiohttp import web
@@ -133,6 +135,33 @@ def async_setup(hass: HomeAssistant) -> None:
 
 class FrigateProxyViewMixin:
     """A mixin for proxying Frigate."""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Wrap _get_proxied_url in subclasses to inject SSL context from config entry."""
+        super().__init_subclass__(**kwargs)
+        if "_get_proxied_url" not in cls.__dict__:
+            return
+
+        original = cls.__dict__["_get_proxied_url"]
+
+        def _make_wrapped(orig: Any) -> Any:
+            def _wrapped(self: Any, request: web.Request, **kw: Any) -> ProxiedURL:
+                result = orig(self, request, **kw)
+                if result.ssl_context is not None:
+                    return result
+                config_entry = self._get_config_entry_for_request(
+                    request, kw.get("frigate_instance_id")
+                )
+                if config_entry and not config_entry.data.get("validate_ssl", True):
+                    ctx = ssl.create_default_context()
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+                    return dataclasses.replace(result, ssl_context=ctx)
+                return result
+
+            return _wrapped
+
+        cls._get_proxied_url = _make_wrapped(original)
 
     def _get_query_params(self, request: web.Request) -> Mapping[str, str]:
         """Get the query params to send upstream."""

--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -146,7 +146,7 @@ class FrigateProxyViewMixin:
 
         def _make_wrapped(orig: Any) -> Any:
             def _wrapped(self: Any, request: web.Request, **kw: Any) -> ProxiedURL:
-                result = orig(self, request, **kw)
+                result: ProxiedURL = orig(self, request, **kw)
                 if result.ssl_context is not None:
                     return result
                 config_entry = self._get_config_entry_for_request(
@@ -156,12 +156,12 @@ class FrigateProxyViewMixin:
                     ctx = ssl.create_default_context()
                     ctx.check_hostname = False
                     ctx.verify_mode = ssl.CERT_NONE
-                    return dataclasses.replace(result, ssl_context=ctx)
+                    return cast(ProxiedURL, dataclasses.replace(result, ssl_context=ctx))
                 return result
 
             return _wrapped
 
-        cls._get_proxied_url = _make_wrapped(original)
+        setattr(cls, "_get_proxied_url", _make_wrapped(original))
 
     def _get_query_params(self, request: web.Request) -> Mapping[str, str]:
         """Get the query params to send upstream."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
-from custom_components.frigate.const import DOMAIN
+from custom_components.frigate.const import CONF_VALIDATE_SSL, DOMAIN
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY, ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
@@ -431,7 +431,7 @@ def create_mock_frigate_config_entry(
     config_entry: MockConfigEntry = MockConfigEntry(
         entry_id=entry_id,
         domain=DOMAIN,
-        data=data or {CONF_URL: TEST_URL, "validate_ssl": validate_ssl},
+        data=data or {CONF_URL: TEST_URL, CONF_VALIDATE_SSL: validate_ssl},
         title=title,
         options=options or {},
         version=2,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -425,12 +425,13 @@ def create_mock_frigate_config_entry(
     options: dict[str, Any] | None = None,
     entry_id: str | None = TEST_CONFIG_ENTRY_ID,
     title: str | None = TEST_URL,
+    validate_ssl: bool = True,
 ) -> MockConfigEntry:
     """Add a test config entry."""
     config_entry: MockConfigEntry = MockConfigEntry(
         entry_id=entry_id,
         domain=DOMAIN,
-        data=data or {CONF_URL: TEST_URL},
+        data=data or {CONF_URL: TEST_URL, "validate_ssl": validate_ssl},
         title=title,
         options=options or {},
         version=2,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,6 +14,7 @@ from custom_components.frigate.const import (
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
     CONF_RTSP_URL_TEMPLATE,
+    CONF_VALIDATE_SSL,
     DOMAIN,
 )
 from homeassistant import config_entries
@@ -63,7 +64,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
         CONF_URL: TEST_URL,
         CONF_PASSWORD: "",
         CONF_USERNAME: "",
-        "validate_ssl": True,
+        CONF_VALIDATE_SSL: True,
     }
     assert len(mock_setup_entry.mock_calls) == 1
     assert mock_client.async_get_stats.called
@@ -92,7 +93,7 @@ async def test_user_success_with_auth(hass: HomeAssistant) -> None:
                 CONF_PASSWORD: TEST_PASSWORD,
                 CONF_URL: TEST_URL,
                 CONF_USERNAME: TEST_USERNAME,
-                "validate_ssl": True,
+                CONF_VALIDATE_SSL: True,
             },
         )
         await hass.async_block_till_done()
@@ -103,7 +104,7 @@ async def test_user_success_with_auth(hass: HomeAssistant) -> None:
         CONF_URL: TEST_URL,
         CONF_PASSWORD: TEST_PASSWORD,
         CONF_USERNAME: TEST_USERNAME,
-        "validate_ssl": True,
+        CONF_VALIDATE_SSL: True,
     }
     assert len(mock_setup_entry.mock_calls) == 1
     assert mock_client.async_get_stats.called

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -962,8 +962,6 @@ async def test_snapshot_proxy_with_ssl_validation_disabled(
     hass_client: Any,
 ) -> None:
     """Test proxy view creates SSL context when SSL validation is disabled."""
-    from hass_web_proxy_lib import ProxiedURL
-
     server = await start_frigate_server(
         aiohttp_server,
         [web.get("/api/events/event_id/snapshot.jpg", response_handler)],
@@ -981,25 +979,12 @@ async def test_snapshot_proxy_with_ssl_validation_disabled(
 
     authenticated_hass_client = await hass_client()
 
-    # Mock the original _get_proxied_url to return a ProxiedURL with no ssl_context.
-    # This allows us to verify the mixin adds one when validate_ssl=False.
-    from custom_components.frigate.views import FrigateProxyViewMixin
-
-    async def get_snapshot_view():
-        """Get the snapshot view to access _get_proxied_url."""
-        app = hass.data.get("http").app
-        for route in app.router.routes():
-            if hasattr(route.resource, "canonical"):
-                if "/api/frigate/snapshot/" in route.resource.canonical:
-                    return route._handler
-        return None
-
     # Patch ssl.create_default_context to verify it's called when SSL validation is disabled.
     original_ssl_context = ssl.create_default_context
 
     ssl_context_created = False
 
-    def mock_create_default_context():
+    def mock_create_default_context() -> ssl.SSLContext:
         nonlocal ssl_context_created
         ssl_context_created = True
         ctx = original_ssl_context()
@@ -1018,8 +1003,6 @@ async def test_snapshot_proxy_with_ssl_validation_enabled(
     hass_client: Any,
 ) -> None:
     """Test proxy view does not modify SSL context when SSL validation is enabled."""
-    from hass_web_proxy_lib import ProxiedURL
-
     server = await start_frigate_server(
         aiohttp_server,
         [web.get("/api/events/event_id/snapshot.jpg", response_handler)],
@@ -1041,7 +1024,7 @@ async def test_snapshot_proxy_with_ssl_validation_enabled(
     original_ssl_context = ssl.create_default_context
     ssl_context_created = False
 
-    def mock_create_default_context():
+    def mock_create_default_context() -> ssl.SSLContext:
         nonlocal ssl_context_created
         ssl_context_created = True
         return original_ssl_context()
@@ -1055,12 +1038,14 @@ async def test_snapshot_proxy_with_ssl_validation_enabled(
 
 async def test_snapshot_proxy_with_ssl_context_already_set() -> None:
     """Test proxy view returns early when ssl_context is already provided."""
-    from hass_web_proxy_lib import ProxiedURL, ProxyView
     from unittest.mock import Mock
+
+    from hass_web_proxy_lib import ProxiedURL, ProxyView
+
     from custom_components.frigate.views import FrigateProxyViewMixin
 
     class TestView(FrigateProxyViewMixin, ProxyView):
-        def _get_proxied_url(self, request, **kwargs: Any) -> ProxiedURL:
+        def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
             return ProxiedURL(
                 url="https://example.com",
                 headers={},
@@ -1075,7 +1060,7 @@ async def test_snapshot_proxy_with_ssl_context_already_set() -> None:
     original_ssl_context = ssl.create_default_context
     ssl_context_created = False
 
-    def mock_create_default_context():
+    def mock_create_default_context() -> ssl.SSLContext:
         nonlocal ssl_context_created
         ssl_context_created = True
         return original_ssl_context()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,7 @@ import copy
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 import logging
+import ssl
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -953,3 +954,134 @@ async def test_review_clips_with_frigate_instance_id(
         "/api/frigate/NOT_A_REAL_ID/clips/review/thumb-abc123.webp"
     )
     assert resp.status == HTTPStatus.NOT_FOUND
+
+
+async def test_snapshot_proxy_with_ssl_validation_disabled(
+    hass: Any,
+    aiohttp_server: Any,
+    hass_client: Any,
+) -> None:
+    """Test proxy view creates SSL context when SSL validation is disabled."""
+    from hass_web_proxy_lib import ProxiedURL
+
+    server = await start_frigate_server(
+        aiohttp_server,
+        [web.get("/api/events/event_id/snapshot.jpg", response_handler)],
+    )
+
+    client = create_mock_frigate_client()
+    client.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
+    config_entry = create_mock_frigate_config_entry(
+        hass,
+        data={CONF_URL: str(server.make_url("/")), "validate_ssl": False},
+    )
+    await setup_mock_frigate_config_entry(
+        hass, config_entry=config_entry, client=client
+    )
+
+    authenticated_hass_client = await hass_client()
+
+    # Mock the original _get_proxied_url to return a ProxiedURL with no ssl_context.
+    # This allows us to verify the mixin adds one when validate_ssl=False.
+    from custom_components.frigate.views import FrigateProxyViewMixin
+
+    async def get_snapshot_view():
+        """Get the snapshot view to access _get_proxied_url."""
+        app = hass.data.get("http").app
+        for route in app.router.routes():
+            if hasattr(route.resource, "canonical"):
+                if "/api/frigate/snapshot/" in route.resource.canonical:
+                    return route._handler
+        return None
+
+    # Patch ssl.create_default_context to verify it's called when SSL validation is disabled.
+    original_ssl_context = ssl.create_default_context
+
+    ssl_context_created = False
+
+    def mock_create_default_context():
+        nonlocal ssl_context_created
+        ssl_context_created = True
+        ctx = original_ssl_context()
+        return ctx
+
+    with patch("ssl.create_default_context", side_effect=mock_create_default_context):
+        resp = await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
+        assert resp.status == HTTPStatus.OK
+        # Verify SSL context was created due to validate_ssl=False
+        assert ssl_context_created
+
+
+async def test_snapshot_proxy_with_ssl_validation_enabled(
+    hass: Any,
+    aiohttp_server: Any,
+    hass_client: Any,
+) -> None:
+    """Test proxy view does not modify SSL context when SSL validation is enabled."""
+    from hass_web_proxy_lib import ProxiedURL
+
+    server = await start_frigate_server(
+        aiohttp_server,
+        [web.get("/api/events/event_id/snapshot.jpg", response_handler)],
+    )
+
+    client = create_mock_frigate_client()
+    client.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
+    config_entry = create_mock_frigate_config_entry(
+        hass,
+        data={CONF_URL: str(server.make_url("/")), "validate_ssl": True},
+    )
+    await setup_mock_frigate_config_entry(
+        hass, config_entry=config_entry, client=client
+    )
+
+    authenticated_hass_client = await hass_client()
+
+    # Patch ssl.create_default_context to verify it's NOT called when SSL validation is enabled.
+    original_ssl_context = ssl.create_default_context
+    ssl_context_created = False
+
+    def mock_create_default_context():
+        nonlocal ssl_context_created
+        ssl_context_created = True
+        return original_ssl_context()
+
+    with patch("ssl.create_default_context", side_effect=mock_create_default_context):
+        resp = await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
+        assert resp.status == HTTPStatus.OK
+        # Verify SSL context was NOT created since validate_ssl=True (default behavior)
+        assert not ssl_context_created
+
+
+async def test_snapshot_proxy_with_ssl_context_already_set() -> None:
+    """Test proxy view returns early when ssl_context is already provided."""
+    from hass_web_proxy_lib import ProxiedURL, ProxyView
+    from unittest.mock import Mock
+    from custom_components.frigate.views import FrigateProxyViewMixin
+
+    class TestView(FrigateProxyViewMixin, ProxyView):
+        def _get_proxied_url(self, request, **kwargs: Any) -> ProxiedURL:
+            return ProxiedURL(
+                url="https://example.com",
+                headers={},
+                query_params={},
+                ssl_context=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+            )
+
+    view = object.__new__(TestView)
+    request = Mock()
+    request.app = {}
+
+    original_ssl_context = ssl.create_default_context
+    ssl_context_created = False
+
+    def mock_create_default_context():
+        nonlocal ssl_context_created
+        ssl_context_created = True
+        return original_ssl_context()
+
+    with patch("ssl.create_default_context", side_effect=mock_create_default_context):
+        result = view._get_proxied_url(request)
+
+    assert result.ssl_context is not None
+    assert not ssl_context_created

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1045,7 +1045,9 @@ async def test_snapshot_proxy_with_ssl_context_already_set() -> None:
     from custom_components.frigate.views import FrigateProxyViewMixin
 
     class TestView(FrigateProxyViewMixin, ProxyView):
-        def _get_proxied_url(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
+        def _get_proxied_url_impl(
+            self, request: web.Request, **kwargs: Any
+        ) -> ProxiedURL:
             return ProxiedURL(
                 url="https://example.com",
                 headers={},

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -20,6 +20,7 @@ from custom_components.frigate.const import (
     ATTR_MQTT,
     CONF_NOTIFICATION_PROXY_ENABLE,
     CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS,
+    CONF_VALIDATE_SSL,
     DOMAIN,
 )
 from homeassistant.components.http.auth import async_sign_path
@@ -971,7 +972,7 @@ async def test_snapshot_proxy_with_ssl_validation_disabled(
     client.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
     config_entry = create_mock_frigate_config_entry(
         hass,
-        data={CONF_URL: str(server.make_url("/")), "validate_ssl": False},
+        data={CONF_URL: str(server.make_url("/")), CONF_VALIDATE_SSL: False},
     )
     await setup_mock_frigate_config_entry(
         hass, config_entry=config_entry, client=client
@@ -1012,7 +1013,7 @@ async def test_snapshot_proxy_with_ssl_validation_enabled(
     client.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
     config_entry = create_mock_frigate_config_entry(
         hass,
-        data={CONF_URL: str(server.make_url("/")), "validate_ssl": True},
+        data={CONF_URL: str(server.make_url("/")), CONF_VALIDATE_SSL: True},
     )
     await setup_mock_frigate_config_entry(
         hass, config_entry=config_entry, client=client


### PR DESCRIPTION
Attempt to fix https://github.com/blakeblackshear/frigate-hass-integration/issues/1087

proxy views ignored the validate_ssl=False config entry setting, so users with self-signed certs on Frigate would get SSL errors despite having opted out of validation