### PR TITLE
Use titlecase instead of .title()

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -416,7 +416,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             and valid_entity_id(new_id)
             and not entity_registry.async_get(new_id)
         ):
-            new_name = f"{get_friendly_name(cam_name)} {obj_name} Count".title()
+            new_name = titlecase(f"{get_friendly_name(cam_name)} {obj_name} Count")
             entity_registry.async_update_entity(
                 entity_id=entity_id,
                 new_entity_id=new_id,

--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -264,9 +264,9 @@ def get_zones(config: dict[str, Any]) -> set[str]:
     return cameras_zones
 
 
-def decode_if_necessary(data: str | bytes) -> str:
+def decode_if_necessary(data: str | bytes | bytearray) -> str:
     """Decode a string if necessary."""
-    return data.decode("utf-8") if isinstance(data, bytes) else data
+    return data.decode("utf-8") if isinstance(data, (bytes, bytearray)) else data
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/frigate/image.py
+++ b/custom_components/frigate/image.py
@@ -6,6 +6,8 @@ import datetime
 import logging
 from typing import Any
 
+from titlecase import titlecase
+
 from homeassistant.components.image import ImageEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
@@ -111,7 +113,8 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, ImageEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return get_friendly_name(self._obj_name).title()
+        result: str = titlecase(get_friendly_name(self._obj_name))
+        return result
 
     @property
     def image_last_updated(self) -> datetime.datetime | None:

--- a/custom_components/frigate/media_source.py
+++ b/custom_components/frigate/media_source.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import attr
 from dateutil.relativedelta import relativedelta
+from titlecase import titlecase
 
 from homeassistant.components.media_player.const import MediaClass, MediaType
 from homeassistant.components.media_source.error import MediaSourceError, Unresolvable
@@ -784,7 +785,7 @@ class FrigateMediaSource(MediaSource):
         if identifier.is_root():
             title = f"{identifier.frigate_media_type.value.capitalize()} ({count})"
         else:
-            title = f"{' > '.join([s for s in get_friendly_name(identifier.name).split('.') if s != '']).title()} ({count})"
+            title = f"{titlecase(' > '.join([s for s in get_friendly_name(identifier.name).split('.') if s != '']))} ({count})"
 
         base = BrowseMediaSource(
             domain=DOMAIN,

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -8,6 +8,8 @@ import json
 import logging
 from typing import Any
 
+from titlecase import titlecase
+
 from homeassistant.components.sensor import (
     RestoreSensor,
     SensorDeviceClass,
@@ -873,7 +875,8 @@ class FrigateActiveObjectCountSensor(FrigateMQTTEntity, SensorEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{get_friendly_name(self._obj_name)} active count".title()
+        result: str = titlecase(f"{get_friendly_name(self._obj_name)} active count")
+        return result
 
     @property
     def native_value(self) -> int:
@@ -1139,7 +1142,8 @@ class FrigateRecognizedFaceSensor(FrigateMQTTEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the value of the sensor."""
-        return str(self._state).title()
+        result: str = titlecase(str(self._state))
+        return result
 
     @property
     def icon(self) -> str:
@@ -1191,7 +1195,7 @@ class FrigateRecognizedPlateSensor(FrigateMQTTEntity, SensorEntity):
                 return
 
             if data.get("name"):
-                self._state = str(data["name"]).title()
+                self._state = titlecase(str(data["name"]))
             else:
                 self._state = str(data["plate"])
 
@@ -1399,9 +1403,9 @@ class FrigateObjectClassificationSensor(FrigateMQTTEntity, SensorEntity):
 
             # Extract sub_label or attribute from the payload
             if "sub_label" in data:
-                self._state = str(data["sub_label"]).replace("_", " ").title()
+                self._state = titlecase(str(data["sub_label"]).replace("_", " "))
             elif "attribute" in data:
-                self._state = str(data["attribute"]).replace("_", " ").title()
+                self._state = titlecase(str(data["attribute"]).replace("_", " "))
             else:
                 return
 

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from titlecase import titlecase
+
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -188,7 +190,8 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return f"{get_friendly_name(self._descriptive_name)}".title()
+        result: str = titlecase(get_friendly_name(self._descriptive_name))
+        return result
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
Replace `str.title()` calls with `titlecase()` from the `titlecase` library for consistent, smarter title casing (lowercase articles/prepositions, no "Don'T-style" apostrophe splits).

Some users may need to update automations or templates.

Also, widen `decode_if_necessary` to accept `bytearray` for mypy 2.0 `strict-bytes`. Per the mypy 2.0 release notes (per PEP 688): "mypy no longer treats `bytearray` and `memoryview` values as assignable to the `bytes` type."

Before mypy 2.0, `bytearray` was implicitly assignable to `bytes`, even though HA widened `ReceivePayloadType` to `str | bytes | bytearray` back in Dec 2024, mypy silently accepted passing it to a `str | bytes` parameter. Mypy 2.0 removed that leniency.