### PR TITLE
Fix live.streams stream selection to use go2rtc names from values

### DIFF
--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -260,6 +260,8 @@ class FrigateCamera(
 
         Checks live.streams from camera config first (prefer matching name,
         fallback to first entry), then checks go2rtc.streams for camera name.
+        live.streams maps {friendly_name: go2rtc_stream_name}, so the stream
+        name is the dict value.
         """
         go2rtc_streams: dict[str, list[str]] = self._frigate_config.get(
             "go2rtc", {}
@@ -269,12 +271,13 @@ class FrigateCamera(
         )
 
         if live_streams:
+            stream_names = list(live_streams.values())
             # Prefer a stream matching the camera name
-            for stream in live_streams:
+            for stream in stream_names:
                 if stream in go2rtc_streams and stream == self._cam_name:
                     return stream
             # Otherwise use the first stream in the dict
-            first_stream = next(iter(live_streams))
+            first_stream = stream_names[0]
             if first_stream in go2rtc_streams:
                 return first_stream
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -408,7 +408,7 @@ async def test_frigate_camera_live_streams_matching_name(hass: HomeAssistant) ->
     config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     config["go2rtc"]["streams"]["front_door_hd"] = "rtsp://rtsp:password@cam/hd"
     config["cameras"]["front_door"]["live"] = {
-        "streams": {"front_door_hd": "hd_stream", "front_door": "default_stream"},
+        "streams": {"HD": "front_door_hd", "Default": "front_door"},
     }
     client = create_mock_frigate_client()
     client.async_get_config = AsyncMock(return_value=config)
@@ -433,7 +433,7 @@ async def test_frigate_camera_live_streams_no_matching_name(
     config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     config["go2rtc"]["streams"]["front_door_hd"] = "rtsp://rtsp:password@cam/hd"
     config["cameras"]["front_door"]["live"] = {
-        "streams": {"front_door_hd": "hd_stream"},
+        "streams": {"HD": "front_door_hd"},
     }
     client = create_mock_frigate_client()
     client.async_get_config = AsyncMock(return_value=config)
@@ -457,7 +457,7 @@ async def test_frigate_camera_live_streams_first_not_in_go2rtc(
 
     config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
     config["cameras"]["front_door"]["live"] = {
-        "streams": {"nonexistent_stream": "some_value"},
+        "streams": {"Some Label": "nonexistent_stream"},
     }
     client = create_mock_frigate_client()
     client.async_get_config = AsyncMock(return_value=config)
@@ -472,6 +472,39 @@ async def test_frigate_camera_live_streams_first_not_in_go2rtc(
     )
     assert stream_source
     assert stream_source.endswith("/front_door")
+
+
+async def test_frigate_camera_live_streams_named_streams(hass: HomeAssistant) -> None:
+    """Test live.streams shaped per Frigate's schema: {friendly_name: stream_name}.
+
+    The camera name itself is not a go2rtc stream; only named variants are. The
+    go2rtc stream name is the dict value, not the key.
+    """
+
+    config: dict[str, Any] = copy.deepcopy(TEST_CONFIG)
+    config["go2rtc"]["streams"] = {
+        "front_door_main": "rtsp://rtsp:password@cam/main",
+        "front_door_sub": "rtsp://rtsp:password@cam/sub",
+    }
+    config["cameras"]["front_door"]["live"] = {
+        "streams": {
+            "Main Stream": "front_door_main",
+            "Sub Stream": "front_door_sub",
+        },
+    }
+    client = create_mock_frigate_client()
+    client.async_get_config = AsyncMock(return_value=config)
+    await setup_mock_frigate_config_entry(hass, client=client)
+
+    entity_state = hass.states.get(TEST_CAMERA_FRONT_DOOR_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "streaming"
+
+    stream_source = await async_get_stream_source(
+        hass, TEST_CAMERA_FRONT_DOOR_ENTITY_ID
+    )
+    assert stream_source
+    assert stream_source.endswith("/front_door_main")
 
 
 async def test_frigate_camera_recording_camera_state(


### PR DESCRIPTION
Frigate's `live.streams` config maps `{friendly_name: go2rtc_stream_name}`, so the go2rtc stream name is the dict **value**, not the key. Stream selection iterated over the keys (the friendly labels), which only resolved correctly when a label happened to be identical to its stream name. Iterating over the values fixes selection for the documented schema.

Follow-up to #1067 / #1066. Adds a regression test for the named-stream shape; existing tests updated to use the correct `{label: stream}` orientation.

🤖 AI-assisted (Claude), human-reviewed.