### PR TITLE
Remove advanced options gate

### DIFF
--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -161,9 +161,6 @@ class FrigateOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        if not self.show_advanced_options:
-            return self.async_abort(reason="only_advanced_options")
-
         schema: dict[Any, Any] = {
             # Whether to enable Frigate-native WebRTC for camera streaming
             vol.Optional(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -281,26 +281,3 @@ async def test_options_advanced(hass: HomeAssistant) -> None:
         assert result["data"][CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS] == 60
         assert not result["data"][CONF_NOTIFICATION_PROXY_ENABLE]
         assert not result["data"][CONF_MEDIA_BROWSER_ENABLE]
-
-
-async def test_options(hass: HomeAssistant) -> None:
-    """Check an options flow without advanced options."""
-
-    config_entry = create_mock_frigate_config_entry(hass)
-    mock_client = create_mock_frigate_client()
-
-    with patch(
-        "custom_components.frigate.config_flow.FrigateApiClient",
-        return_value=mock_client,
-    ), patch(
-        "custom_components.frigate.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.async_block_till_done()
-
-        result = await hass.config_entries.options.async_init(
-            config_entry.entry_id,
-        )
-
-        assert result["type"] == FlowResultType.ABORT
-        assert result["reason"] == "only_advanced_options"


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2026/05/26/advanced-mode-config-flow-deprecation/

> The FlowHandler.show_advanced_options property has been deprecated and will be removed with the release of Home Assistant Core 2027.6. During the deprecation period, FlowHandler.show_advanced_options **unconditionally returns True** to not make options gated by this flag inaccessible to users.

For 2026.6.0 compat.