### PR TITLE
Add configurable auth mode for proxy authentication support

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -51,7 +51,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.loader import async_get_integration
 from homeassistant.util import slugify
 
-from .api import FrigateApiClient, FrigateApiClientError
+from .api import AUTH_MODE_LOGIN, FrigateApiClient, FrigateApiClientError
 from .const import (
     ATTR_CLIENT,
     ATTR_CONFIG,
@@ -62,6 +62,7 @@ from .const import (
     ATTR_START_TIME,
     ATTR_WS_EVENT_PROXY,
     ATTR_WS_REVIEW_PROXY,
+    CONF_AUTH_MODE,
     CONF_CAMERA_STATIC_IMAGE_HEIGHT,
     CONF_RTMP_URL_TEMPLATE,
     CONF_VALIDATE_SSL,
@@ -344,6 +345,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
         entry.data.get(CONF_VALIDATE_SSL, True),
+        entry.data.get(CONF_AUTH_MODE, AUTH_MODE_LOGIN),
     )
     coordinator = FrigateDataUpdateCoordinator(hass, client=client)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/frigate/api.py
+++ b/custom_components/frigate/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import datetime
 import logging
 import socket
@@ -20,6 +21,23 @@ REVIEW_SUMMARIZE_TIMEOUT = 60
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 HEADERS = {"Content-type": "application/json; charset=UTF-8"}
+
+# Authentication modes for reaching Frigate:
+# - AUTH_MODE_LOGIN (default): Frigate's native JWT login via POST /api/login
+#   using the username/password.
+# - AUTH_MODE_BASIC: send a Basic Authorization header built from the
+#   username/password on every request, for reverse proxies that perform HTTP
+#   Basic Auth in front of Frigate (Frigate's own login is never called).
+# - AUTH_MODE_BEARER: send a Bearer Authorization header with the password as
+#   a static token on every request, for reverse proxies that expect a static
+#   bearer token (the username is ignored in this mode).
+AUTH_MODE_LOGIN = "login"
+AUTH_MODE_BASIC = "basic"
+AUTH_MODE_BEARER = "bearer"
+AUTH_MODES = (AUTH_MODE_LOGIN, AUTH_MODE_BASIC, AUTH_MODE_BEARER)
+
+# The auth modes intended for a reverse proxy in front of Frigate.
+PROXY_AUTH_MODES = (AUTH_MODE_BASIC, AUTH_MODE_BEARER)
 
 # ==============================================================================
 # Please do not add HomeAssistant specific imports/functionality to this module,
@@ -42,6 +60,7 @@ class FrigateApiClient:
         username: str | None = None,
         password: str | None = None,
         validate_ssl: bool = True,
+        auth_mode: str = AUTH_MODE_LOGIN,
     ) -> None:
         """Construct API Client."""
         self._host = host
@@ -50,6 +69,17 @@ class FrigateApiClient:
         self._password = password
         self._token_data: dict[str, Any] = {}
         self.validate_ssl = validate_ssl
+        # See the AUTH_MODE_* constants for the semantics of each mode.
+        self._auth_mode = auth_mode
+        # Precomputed Authorization header value for the proxy auth modes,
+        # or None if the required credentials are not configured (in which
+        # case no Authorization header is sent).
+        self._proxy_auth_header: str | None = None
+        if auth_mode == AUTH_MODE_BASIC and username and password:
+            credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+            self._proxy_auth_header = f"Basic {credentials}"
+        elif auth_mode == AUTH_MODE_BEARER and password:
+            self._proxy_auth_header = f"Bearer {password}"
 
     async def async_get_version(self) -> str:
         """Get data from the API."""
@@ -458,9 +488,18 @@ class FrigateApiClient:
 
     async def get_auth_headers(self) -> dict[str, str]:
         """
-        Get headers for API requests, including the JWT token if available.
-        Ensures that the token is refreshed if needed.
+        Get headers for API requests, based on the configured auth mode.
+
+        In the proxy auth modes (AUTH_MODE_BASIC/AUTH_MODE_BEARER) a static
+        Authorization header is returned and Frigate's native login is never
+        called. In AUTH_MODE_LOGIN (default) the JWT token obtained via
+        Frigate's native login is included, refreshing it if needed.
         """
+        if self._auth_mode in PROXY_AUTH_MODES:
+            if self._proxy_auth_header:
+                return {"Authorization": self._proxy_auth_header}
+            return {}
+
         headers = {}
 
         if self._username and self._password:

--- a/custom_components/frigate/config_flow.py
+++ b/custom_components/frigate/config_flow.py
@@ -12,11 +12,19 @@ from yarl import URL
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .api import FrigateApiClient, FrigateApiClientError
+from .api import (
+    AUTH_MODE_BASIC,
+    AUTH_MODE_BEARER,
+    AUTH_MODE_LOGIN,
+    AUTH_MODES,
+    FrigateApiClient,
+    FrigateApiClientError,
+)
 from .const import (
+    CONF_AUTH_MODE,
     CONF_ENABLE_WEBRTC,
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
@@ -77,6 +85,21 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except vol.Invalid:
             return self._show_config_form(user_input, errors={"base": "invalid_url"})
 
+        # The proxy auth modes send static credentials, so require them upfront
+        # instead of failing with a generic connection error (or silently
+        # storing an entry that sends no credentials at all).
+        auth_mode = user_input.get(CONF_AUTH_MODE, AUTH_MODE_LOGIN)
+        if auth_mode == AUTH_MODE_BASIC and not (
+            user_input.get(CONF_USERNAME) and user_input.get(CONF_PASSWORD)
+        ):
+            return self._show_config_form(
+                user_input, errors={"base": "basic_auth_missing_credentials"}
+            )
+        if auth_mode == AUTH_MODE_BEARER and not user_input.get(CONF_PASSWORD):
+            return self._show_config_form(
+                user_input, errors={"base": "bearer_auth_missing_token"}
+            )
+
         try:
             session = async_create_clientsession(self.hass)
             client = FrigateApiClient(
@@ -85,6 +108,7 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_USERNAME),
                 user_input.get(CONF_PASSWORD),
                 user_input.get(CONF_VALIDATE_SSL, True),
+                user_input.get(CONF_AUTH_MODE, AUTH_MODE_LOGIN),
             )
             await client.async_get_stats()
         except FrigateApiClientError:
@@ -133,6 +157,16 @@ class FrigateFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")
                     ): str,
+                    vol.Optional(
+                        CONF_AUTH_MODE,
+                        default=user_input.get(CONF_AUTH_MODE, AUTH_MODE_LOGIN),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=list(AUTH_MODES),
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            translation_key=CONF_AUTH_MODE,
+                        )
+                    ),
                 }
             ),
             errors=errors,

--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -58,6 +58,7 @@ CONF_NOTIFICATION_PROXY_ENABLE = "notification_proxy_enable"
 CONF_NOTIFICATION_PROXY_EXPIRE_AFTER_SECONDS = "notification_proxy_expire_after_seconds"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+CONF_AUTH_MODE = "auth_mode"
 CONF_PATH = "path"
 CONF_RTSP_URL_TEMPLATE = "rtsp_url_template"
 

--- a/custom_components/frigate/translations/en.json
+++ b/custom_components/frigate/translations/en.json
@@ -7,16 +7,31 @@
           "url": "URL",
           "validate_ssl": "Validate SSL",
           "username": "Username (optional)",
-          "password": "Password (optional)"
+          "password": "Password (optional)",
+          "auth_mode": "Authentication mode"
+        },
+        "data_description": {
+          "auth_mode": "'Frigate login' uses Frigate's native username/password login. 'HTTP Basic Auth' sends the username/password as a Basic Authorization header on every request (for reverse proxies enforcing Basic Auth in front of Frigate). 'Bearer token' sends the password as a static Bearer Authorization header on every request (username is ignored); use this for reverse proxies that expect a static token."
         }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect",
-      "invalid_url": "Invalid URL"
+      "invalid_url": "Invalid URL",
+      "basic_auth_missing_credentials": "HTTP Basic Auth requires both a username and a password",
+      "bearer_auth_missing_token": "Bearer token authentication requires the token to be entered in the password field"
     },
     "abort": {
       "already_configured": "Device is already configured"
+    }
+  },
+  "selector": {
+    "auth_mode": {
+      "options": {
+        "login": "Frigate login",
+        "basic": "HTTP Basic Auth",
+        "bearer": "Bearer token"
+      }
     }
   },
   "options": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,12 @@ from aiohttp import web
 import jwt
 import pytest
 
-from custom_components.frigate.api import FrigateApiClient, FrigateApiClientError
+from custom_components.frigate.api import (
+    AUTH_MODE_BASIC,
+    AUTH_MODE_BEARER,
+    FrigateApiClient,
+    FrigateApiClientError,
+)
 
 from . import TEST_SERVER_VERSION, start_frigate_server
 
@@ -1147,3 +1152,80 @@ async def test_async_set_reviews_viewed(
         )
         == post_success
     )
+
+
+async def test_get_auth_headers_basic_mode(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test get_auth_headers sends Basic auth and never calls /api/login."""
+    login_handler = AsyncMock(return_value=web.Response(status=200))
+
+    server = await start_frigate_server(
+        aiohttp_server, [web.post("/api/login", login_handler)]
+    )
+    frigate_client = FrigateApiClient(
+        str(server.make_url("/")),
+        aiohttp_session,
+        username="user",
+        password="pass",
+        auth_mode=AUTH_MODE_BASIC,
+    )
+
+    headers = await frigate_client.get_auth_headers()
+
+    assert headers == {"Authorization": "Basic dXNlcjpwYXNz"}
+    assert not login_handler.called
+
+
+async def test_get_auth_headers_basic_mode_missing_credentials(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test get_auth_headers omits Basic auth when credentials are missing."""
+    server = await start_frigate_server(aiohttp_server, [])
+    frigate_client = FrigateApiClient(
+        str(server.make_url("/")),
+        aiohttp_session,
+        auth_mode=AUTH_MODE_BASIC,
+    )
+
+    headers = await frigate_client.get_auth_headers()
+
+    assert headers == {}
+
+
+async def test_get_auth_headers_bearer_mode(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test get_auth_headers sends a static token and never calls /api/login."""
+    login_handler = AsyncMock(return_value=web.Response(status=200))
+
+    server = await start_frigate_server(
+        aiohttp_server, [web.post("/api/login", login_handler)]
+    )
+    frigate_client = FrigateApiClient(
+        str(server.make_url("/")),
+        aiohttp_session,
+        password="static-token",
+        auth_mode=AUTH_MODE_BEARER,
+    )
+
+    headers = await frigate_client.get_auth_headers()
+
+    assert headers == {"Authorization": "Bearer static-token"}
+    assert not login_handler.called
+
+
+async def test_get_auth_headers_bearer_mode_missing_password(
+    aiohttp_session: aiohttp.ClientSession, aiohttp_server: Any
+) -> None:
+    """Test get_auth_headers omits Bearer auth when no password is set."""
+    server = await start_frigate_server(aiohttp_server, [])
+    frigate_client = FrigateApiClient(
+        str(server.make_url("/")),
+        aiohttp_session,
+        auth_mode=AUTH_MODE_BEARER,
+    )
+
+    headers = await frigate_client.get_auth_headers()
+
+    assert headers == {}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,8 +7,14 @@ from unittest.mock import AsyncMock, patch
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.frigate.api import FrigateApiClientError
+from custom_components.frigate.api import (
+    AUTH_MODE_BASIC,
+    AUTH_MODE_BEARER,
+    AUTH_MODE_LOGIN,
+    FrigateApiClientError,
+)
 from custom_components.frigate.const import (
+    CONF_AUTH_MODE,
     CONF_ENABLE_WEBRTC,
     CONF_MEDIA_BROWSER_ENABLE,
     CONF_NOTIFICATION_PROXY_ENABLE,
@@ -64,6 +70,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
         CONF_URL: TEST_URL,
         CONF_PASSWORD: "",
         CONF_USERNAME: "",
+        CONF_AUTH_MODE: AUTH_MODE_LOGIN,
         CONF_VALIDATE_SSL: True,
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -104,6 +111,49 @@ async def test_user_success_with_auth(hass: HomeAssistant) -> None:
         CONF_URL: TEST_URL,
         CONF_PASSWORD: TEST_PASSWORD,
         CONF_USERNAME: TEST_USERNAME,
+        CONF_AUTH_MODE: AUTH_MODE_LOGIN,
+        CONF_VALIDATE_SSL: True,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_client.async_get_stats.called
+
+
+async def test_user_success_with_basic_auth_mode(hass: HomeAssistant) -> None:
+    """Test successful user flow with HTTP Basic Auth mode selected."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    mock_client = create_mock_frigate_client()
+
+    with patch(
+        "custom_components.frigate.config_flow.FrigateApiClient",
+        return_value=mock_client,
+    ), patch(
+        "custom_components.frigate.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_PASSWORD: TEST_PASSWORD,
+                CONF_URL: TEST_URL,
+                CONF_USERNAME: TEST_USERNAME,
+                CONF_AUTH_MODE: AUTH_MODE_BASIC,
+                CONF_VALIDATE_SSL: True,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "example.com"
+    assert result["data"] == {
+        CONF_URL: TEST_URL,
+        CONF_PASSWORD: TEST_PASSWORD,
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_AUTH_MODE: AUTH_MODE_BASIC,
         CONF_VALIDATE_SSL: True,
     }
     assert len(mock_setup_entry.mock_calls) == 1
@@ -206,6 +256,51 @@ async def test_user_invalid_url(hass: HomeAssistant) -> None:
     assert result["type"] == "form"
     assert result["errors"]
     assert result["errors"]["base"] == "invalid_url"
+
+
+async def test_user_basic_auth_mode_missing_credentials(hass: HomeAssistant) -> None:
+    """Test Basic Auth mode requires both username and password."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: TEST_URL,
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_AUTH_MODE: AUTH_MODE_BASIC,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["errors"]
+    assert result["errors"]["base"] == "basic_auth_missing_credentials"
+
+
+async def test_user_bearer_auth_mode_missing_token(hass: HomeAssistant) -> None:
+    """Test Bearer token mode requires a password (the token)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert not result["errors"]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_URL: TEST_URL,
+            CONF_AUTH_MODE: AUTH_MODE_BEARER,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["errors"]
+    assert result["errors"]["base"] == "bearer_auth_missing_token"
 
 
 async def test_duplicate(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Add an "Authentication mode" option to the config flow, allowing the existing username/password fields to be reinterpreted for proxy-authentication setups (e.g. Authelia) instead of always using Frigate's native login flow:

- Frigate login (default): unchanged, POSTs to /api/login for a JWT
- HTTP Basic Auth: sends "Authorization: Basic base64(user:pass)" on every request
- Bearer token: sends "Authorization: Bearer <password>", treating the password field as a static token

This lets users behind a forward-auth proxy that expects Basic or Bearer credentials authenticate without hardcoding credentials in the URL.

Fixes #1046.

Generated by 🤖, reviewed by me.