### PR TITLE
Use cached SSL context to avoid blocking calls in proxy views

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -7,7 +7,6 @@ import dataclasses
 import datetime
 import logging
 import os
-import ssl
 from typing import Any, Optional, cast
 
 from aiohttp import web
@@ -40,6 +39,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import get_default_no_verify_context
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -146,10 +146,9 @@ class FrigateProxyViewMixin:
             request, kwargs.get("frigate_instance_id")
         )
         if config_entry and not config_entry.data.get(CONF_VALIDATE_SSL, True):
-            ctx = ssl.create_default_context()
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-            return dataclasses.replace(result, ssl_context=ctx)
+            return dataclasses.replace(
+                result, ssl_context=get_default_no_verify_context()
+            )
         return result
 
     def _get_proxied_url_impl(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -980,22 +980,14 @@ async def test_snapshot_proxy_with_ssl_validation_disabled(
 
     authenticated_hass_client = await hass_client()
 
-    # Patch ssl.create_default_context to verify it's called when SSL validation is disabled.
-    original_ssl_context = ssl.create_default_context
-
-    ssl_context_created = False
-
-    def mock_create_default_context() -> ssl.SSLContext:
-        nonlocal ssl_context_created
-        ssl_context_created = True
-        ctx = original_ssl_context()
-        return ctx
-
-    with patch("ssl.create_default_context", side_effect=mock_create_default_context):
+    mock_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    with patch(
+        "custom_components.frigate.views.get_default_no_verify_context",
+        return_value=mock_ctx,
+    ) as mock_get_ctx:
         resp = await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
         assert resp.status == HTTPStatus.OK
-        # Verify SSL context was created due to validate_ssl=False
-        assert ssl_context_created
+        mock_get_ctx.assert_called_once()
 
 
 async def test_snapshot_proxy_with_ssl_validation_enabled(
@@ -1021,20 +1013,12 @@ async def test_snapshot_proxy_with_ssl_validation_enabled(
 
     authenticated_hass_client = await hass_client()
 
-    # Patch ssl.create_default_context to verify it's NOT called when SSL validation is enabled.
-    original_ssl_context = ssl.create_default_context
-    ssl_context_created = False
-
-    def mock_create_default_context() -> ssl.SSLContext:
-        nonlocal ssl_context_created
-        ssl_context_created = True
-        return original_ssl_context()
-
-    with patch("ssl.create_default_context", side_effect=mock_create_default_context):
+    with patch(
+        "custom_components.frigate.views.get_default_no_verify_context",
+    ) as mock_get_ctx:
         resp = await authenticated_hass_client.get("/api/frigate/snapshot/event_id")
         assert resp.status == HTTPStatus.OK
-        # Verify SSL context was NOT created since validate_ssl=True (default behavior)
-        assert not ssl_context_created
+        mock_get_ctx.assert_not_called()
 
 
 async def test_snapshot_proxy_with_ssl_context_already_set() -> None:
@@ -1060,16 +1044,10 @@ async def test_snapshot_proxy_with_ssl_context_already_set() -> None:
     request = Mock()
     request.app = {}
 
-    original_ssl_context = ssl.create_default_context
-    ssl_context_created = False
-
-    def mock_create_default_context() -> ssl.SSLContext:
-        nonlocal ssl_context_created
-        ssl_context_created = True
-        return original_ssl_context()
-
-    with patch("ssl.create_default_context", side_effect=mock_create_default_context):
+    with patch(
+        "custom_components.frigate.views.get_default_no_verify_context",
+    ) as mock_get_ctx:
         result = view._get_proxied_url(request)
 
     assert result.ssl_context is not None
-    assert not ssl_context_created
+    mock_get_ctx.assert_not_called()


### PR DESCRIPTION
## Summary

`_get_proxied_url` in `FrigateProxyViewMixin` calls `ssl.create_default_context()` on every proxied request when `validate_ssl` is disabled. This triggers `load_default_certs` and `set_default_verify_paths`, both of which do synchronous disk I/O (reading system CA bundles) on the event loop. HA's blocking-call detector fires twice per request:

<details>
<summary>load_default_certs warning + traceback</summary>

```
2026-08-10 11:49:39.025 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to load_default_certs with args (<ssl.SSLContext object at 0x2f90e0d03e0>, <Purpose.SERVER_AUTH: _ASN1Object(nid=129, shortname='serverAuth', longname='TLS Web Server Authentication', oid='1.3.6.1.5.5.7.3.1')>) inside the event loop by custom integration 'frigate' at custom_components/frigate/views.py, line 149: ctx = ssl.create_default_context() (offender: /usr/local/lib/python3.14/ssl.py, line 722: context.load_default_certs(purpose)), please create a bug report at https://github.com/blakeblackshear/frigate-hass-integration/issues
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_default_certs
Traceback (most recent call last):
  File "<frozen runpy>", line 203, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 290, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 2056, in _run_once
    handle._run()
  File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_protocol.py", line 675, in start
    task = asyncio.Task(coro, loop=loop, eager_start=True)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_protocol.py", line 575, in _handle_request
    resp = await request_handler(request)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_app.py", line 559, in _handle
    return await handler(request)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 96, in security_filter_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 80, in forwarded_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 24, in request_context_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 261, in auth_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/headers.py", line 39, in headers_middleware
    response = await handler(request)
  File "/usr/src/homeassistant/homeassistant/helpers/http.py", line 92, in handle
    result = await handler(request, **request.match_info)
  File "/config/custom_components/frigate/views.py", line 214, in get
    return await super().get(request, **kwargs)  # type: ignore[misc]
  File "/usr/local/lib/python3.14/site-packages/hass_web_proxy_lib/__init__.py", line 106, in get
    return await self._handle_request(request, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/hass_web_proxy_lib/__init__.py", line 142, in _handle_request
    url_or_response = self._get_proxied_url_or_handle_error(request, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/hass_web_proxy_lib/__init__.py", line 118, in _get_proxied_url_or_handle_error
    url = self._get_proxied_url(request, **kwargs)
  File "/config/custom_components/frigate/views.py", line 149, in _get_proxied_url
    ctx = ssl.create_default_context()
```
</details>

<details>
<summary>set_default_verify_paths warning + traceback</summary>

```
2026-08-10 11:49:39.034 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to set_default_verify_paths with args (<ssl.SSLContext object at 0x2f90e0d03e0>,) inside the event loop by custom integration 'frigate' at custom_components/frigate/views.py, line 149: ctx = ssl.create_default_context() (offender: /usr/local/lib/python3.14/ssl.py, line 534: self.set_default_verify_paths()), please create a bug report at https://github.com/blakeblackshear/frigate-hass-integration/issues
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#set_default_verify_paths
Traceback (most recent call last):
  File "<frozen runpy>", line 203, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 290, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.14/asyncio/base_events.py", line 2056, in _run_once
    handle._run()
  File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_protocol.py", line 675, in start
    task = asyncio.Task(coro, loop=loop, eager_start=True)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_protocol.py", line 575, in _handle_request
    resp = await request_handler(request)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_app.py", line 559, in _handle
    return await handler(request)
  File "/usr/local/lib/python3.14/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 96, in security_filter_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 80, in forwarded_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 24, in request_context_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 261, in auth_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/headers.py", line 39, in headers_middleware
    response = await handler(request)
  File "/usr/src/homeassistant/homeassistant/helpers/http.py", line 92, in handle
    result = await handler(request, **request.match_info)
  File "/config/custom_components/frigate/views.py", line 214, in get
    return await super().get(request, **kwargs)  # type: ignore[misc]
  File "/usr/local/lib/python3.14/site-packages/hass_web_proxy_lib/__init__.py", line 106, in get
    return await self._handle_request(request, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/hass_web_proxy_lib/__init__.py", line 142, in _handle_request
    url_or_response = self._get_proxied_url_or_handle_error(request, **kwargs)
  File "/usr/local/lib/python3.14/site-packages/hass_web_proxy_lib/__init__.py", line 118, in _get_proxied_url_or_handle_error
    url = self._get_proxied_url(request, **kwargs)
  File "/config/custom_components/frigate/views.py", line 149, in _get_proxied_url
    ctx = ssl.create_default_context()
```
</details>

This is the hot path that serves notification thumbnails and clips through the media proxy, so it blocks precisely while phones are fetching notification media.

The constructed context is immediately mutated to disable all verification (`check_hostname=False`, `verify_mode=CERT_NONE`), so the CA-bundle I/O is entirely wasted.

## Fix

Replace with `homeassistant.util.ssl.get_default_no_verify_context()`, which returns a process-wide `@functools.cache`'d context with verification already disabled. No per-request disk I/O, no mutation of shared state.

## Environment

Integration 5.15.4, HA Core 2026.x, Python 3.14, Frigate 0.17.2.

Closes #1110, closes #1100.
