### PR TITLE
Allow authenticated requests to VOD segments without a signed URL

### DIFF
--- a/custom_components/frigate/views.py
+++ b/custom_components/frigate/views.py
@@ -459,7 +459,20 @@ class VodSegmentProxyView(FrigateProxyView):
 
     def _get_proxied_url_impl(self, request: web.Request, **kwargs: Any) -> ProxiedURL:
         """Create proxied URL."""
-        if not self._async_validate_signed_manifest(request):
+        # A normally-authenticated request (e.g. a Bearer token sent as a header, the
+        # same way every other Frigate proxy view here already accepts it) is allowed
+        # through without also needing a signed authSig. The signature exists for a
+        # different problem: Home Assistant's own frontend media browser plays this
+        # through a plain <video> tag, which can't attach an Authorization header, so
+        # it embeds a scoped, time-limited signature in the URL instead (see
+        # async_sign_path). That's not a reason to *require* a signature from a client
+        # that's already authenticated the normal way — every other proxy view here
+        # (RecordingProxyView included, which also serves a full clip) accepts plain
+        # authentication with no extra signature step; VOD segments were the one
+        # exception, with no fallback for a client that can't/doesn't sign its URLs.
+        if not request[KEY_AUTHENTICATED] and not self._async_validate_signed_manifest(
+            request
+        ):
             raise HASSWebProxyLibUnauthorizedRequestError()
 
         return ProxiedURL(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -143,18 +143,36 @@ async def test_vod_segment_proxy(
     assert resp.status == HTTPStatus.OK
 
 
+async def test_vod_segment_proxy_authenticated_without_signature(
+    local_frigate: Any,
+    hass_client: Any,
+) -> None:
+    """Test that a normally-authenticated request needs no signed authSig.
+
+    A client that authenticates the same way as every other Frigate proxy view
+    here (e.g. a Bearer token as a header) shouldn't also need a signed URL —
+    that mechanism exists for Home Assistant's own frontend media browser,
+    which plays this through a plain <video> tag that can't attach an
+    Authorization header at all.
+    """
+
+    authenticated_hass_client = await hass_client()
+    resp = await authenticated_hass_client.get("/api/frigate/vod/present/segment.ts")
+    assert resp.status == HTTPStatus.OK
+
+
 async def test_vod_segment_proxy_unauthorized(
     hass: HomeAssistant,
     hass_access_token: Any,
     local_frigate: Any,
-    hass_client: Any,
+    hass_client_no_auth: Any,
 ) -> None:
     """Test vod segment."""
 
-    authenticated_hass_client = await hass_client()
+    unauthenticated_hass_client = await hass_client_no_auth()
 
     # No secret set
-    resp = await authenticated_hass_client.get("/api/frigate/vod/present/segment.ts")
+    resp = await unauthenticated_hass_client.get("/api/frigate/vod/present/segment.ts")
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
     refresh_token = hass.auth.async_validate_access_token(hass_access_token)
@@ -168,17 +186,17 @@ async def test_vod_segment_proxy_unauthorized(
     )
 
     # No signature
-    resp = await authenticated_hass_client.get("/api/frigate/vod/present/segment.ts")
+    resp = await unauthenticated_hass_client.get("/api/frigate/vod/present/segment.ts")
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
     # Wrong signature
-    resp = await authenticated_hass_client.get(
+    resp = await unauthenticated_hass_client.get(
         "/api/frigate/vod/present/segment.ts?authSig=invalid"
     )
     assert resp.status == HTTPStatus.UNAUTHORIZED
 
     # Modified path
-    resp = await authenticated_hass_client.get(
+    resp = await unauthenticated_hass_client.get(
         signed_path.replace("/api/frigate/", "/api/frigate/mod/")
     )
     assert resp.status == HTTPStatus.UNAUTHORIZED


### PR DESCRIPTION
## Summary
`VodSegmentProxyView` unconditionally required a signed `authSig` query
parameter, with no fallback for a request that's already authenticated
the normal way (e.g. a Bearer token header). That signature exists to
solve a different problem: Home Assistant's own frontend media browser
plays this through a plain `<video>` tag, which can't attach an
`Authorization` header, so it needs a scoped, time-limited signature
embedded in the URL instead.

A client that authenticates the same way every other Frigate proxy
view here already accepts (`RecordingProxyView` included, which also
serves a full clip) had no way to reach VOD segments at all — only the
manifest worked, since `VodProxyView` has no such restriction. This
meant full continuous VOD playback never actually completed for any
client other than Home Assistant's own frontend.

- Check `request[KEY_AUTHENTICATED]` first, the same way
  `NotificationsProxyView._permit_request()` already does, and only
  fall back to signature validation when the request isn't otherwise
  authenticated.
- Updated `test_vod_segment_proxy_unauthorized` to exercise the
  signature-validation path against an unauthenticated client (its
  actual purpose), and added
  `test_vod_segment_proxy_authenticated_without_signature` to cover
  the new allowed case.

## Test plan
- [x] `black`, `flake8`, `mypy`, `isort`, `pylint --errors-only`,
  `codespell` all pass
- [x] Full `tests/test_views.py` suite passes (39/39)
- [x] Verified live against a real Home Assistant + Frigate instance:
  a third-party client (Android TV app) that previously got `401` on
  every VOD segment (manifest OK, every segment rejected) now plays a
  full continuous VOD clip end-to-end with this patch applied