### PR TITLE
Fix HA 2026.9 device registry via_device compatibility

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -45,7 +45,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er, llm
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.loader import async_get_integration
@@ -105,6 +105,19 @@ def get_frigate_device_identifier(
     if camera_name:
         return (DOMAIN, f"{entry.entry_id}:{slugify(camera_name)}")
     return (DOMAIN, entry.entry_id)
+
+
+def get_frigate_via_device(hass: HomeAssistant, entry: ConfigEntry) -> DeviceInfo:
+    """Get the parent Frigate device link for this Home Assistant version."""
+    identifier = get_frigate_device_identifier(entry)
+    if "via_device_id" in DeviceInfo.__annotations__:
+        device = dr.async_get(hass).async_get_device({identifier})
+        if not device:
+            return {}
+        device_info: DeviceInfo = {}
+        device_info["via_device_id"] = device.id  # type: ignore[typeddict-unknown-key]
+        return device_info
+    return {"via_device": identifier}
 
 
 def get_frigate_entity_unique_id(

--- a/custom_components/frigate/binary_sensor.py
+++ b/custom_components/frigate/binary_sensor.py
@@ -26,6 +26,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
     get_zones,
 )
 from .const import ATTR_CONFIG, DOMAIN, NAME
@@ -125,7 +126,7 @@ class FrigateObjectOccupancySensor(FrigateMQTTEntity, BinarySensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
@@ -206,7 +207,7 @@ class FrigateAudioSensor(FrigateMQTTEntity, BinarySensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -287,7 +288,7 @@ class FrigateMotionSensor(FrigateMQTTEntity, BinarySensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",

--- a/custom_components/frigate/camera.py
+++ b/custom_components/frigate/camera.py
@@ -38,6 +38,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
     verify_frigate_version,
 )
 from .const import (
@@ -350,7 +351,7 @@ class FrigateCamera(
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._url}/#{self._cam_name}",
@@ -552,7 +553,7 @@ class BirdseyeCamera(FrigateEntity, Camera):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, "birdseye")
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": "Birdseye",
             "model": self._get_model(),
             "configuration_url": f"{self._url}/cameras/birdseye",

--- a/custom_components/frigate/image.py
+++ b/custom_components/frigate/image.py
@@ -22,6 +22,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
 )
 from .const import ATTR_CONFIG, DOMAIN, NAME
 
@@ -103,7 +104,7 @@ class FrigateMqttSnapshots(FrigateMQTTEntity, ImageEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",

--- a/custom_components/frigate/number.py
+++ b/custom_components/frigate/number.py
@@ -21,6 +21,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
 )
 from .const import (
     ATTR_CONFIG,
@@ -128,7 +129,7 @@ class FrigateMotionContourArea(FrigateMQTTEntity, NumberEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -221,7 +222,7 @@ class FrigateMotionThreshold(FrigateMQTTEntity, NumberEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",

--- a/custom_components/frigate/sensor.py
+++ b/custom_components/frigate/sensor.py
@@ -41,6 +41,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
     get_known_plates,
     get_object_classification_models_and_cameras,
     get_zones,
@@ -602,7 +603,7 @@ class CameraFpsSensor(
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -677,7 +678,7 @@ class CameraSoundSensor(
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -776,7 +777,7 @@ class FrigateObjectCountSensor(FrigateMQTTEntity, SensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
@@ -865,7 +866,7 @@ class FrigateActiveObjectCountSensor(FrigateMQTTEntity, SensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
@@ -1003,7 +1004,7 @@ class CameraProcessCpuSensor(
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -1127,7 +1128,7 @@ class FrigateRecognizedFaceSensor(FrigateMQTTEntity, SensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
@@ -1234,7 +1235,7 @@ class FrigateRecognizedPlateSensor(FrigateMQTTEntity, SensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name if self._cam_name not in get_zones(self._frigate_config) else ''}",
@@ -1330,7 +1331,7 @@ class FrigateClassificationSensor(FrigateMQTTEntity, RestoreSensor):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -1447,7 +1448,7 @@ class FrigateObjectClassificationSensor(FrigateMQTTEntity, SensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",
@@ -1528,7 +1529,7 @@ class FrigateReviewStatusSensor(FrigateMQTTEntity, SensorEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -22,6 +22,7 @@ from . import (
     get_friendly_name,
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
     verify_frigate_version,
 )
 from .const import ATTR_CONFIG, DOMAIN, NAME
@@ -180,7 +181,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
             "identifiers": {
                 get_frigate_device_identifier(self._config_entry, self._cam_name)
             },
-            "via_device": get_frigate_device_identifier(self._config_entry),
+            **get_frigate_via_device(self.hass, self._config_entry),
             "name": get_friendly_name(self._cam_name),
             "model": self._get_model(),
             "configuration_url": f"{self._config_entry.data.get(CONF_URL)}/cameras/{self._cam_name}",

--- a/custom_components/frigate/update.py
+++ b/custom_components/frigate/update.py
@@ -62,7 +62,6 @@ class FrigateContainerUpdate(
         """Get device information."""
         return {
             "identifiers": {get_frigate_device_identifier(self._config_entry)},
-            "via_device": get_frigate_device_identifier(self._config_entry),
             "name": NAME,
             "model": self._get_model(),
             "configuration_url": self._config_entry.data.get(CONF_URL),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.frigate import (
     get_frigate_device_identifier,
     get_frigate_entity_unique_id,
+    get_frigate_via_device,
 )
 from custom_components.frigate.api import FrigateApiClientError
 from custom_components.frigate.const import (
@@ -24,6 +25,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.loader import async_get_integration
 
 from . import (
@@ -35,6 +37,40 @@ from . import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def test_get_frigate_via_device_legacy(hass: HomeAssistant) -> None:
+    """Test getting the Frigate via_device link on older Home Assistant versions."""
+    config_entry = create_mock_frigate_config_entry(hass)
+
+    assert get_frigate_via_device(hass, config_entry) == {
+        "via_device": get_frigate_device_identifier(config_entry)
+    }
+
+
+async def test_get_frigate_via_device_id(hass: HomeAssistant) -> None:
+    """Test getting the Frigate via_device_id link when Home Assistant supports it."""
+    config_entry = create_mock_frigate_config_entry(hass)
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={get_frigate_device_identifier(config_entry)},
+    )
+
+    with patch.dict(DeviceInfo.__annotations__, {"via_device_id": str}):
+        assert get_frigate_via_device(hass, config_entry) == {
+            "via_device_id": device.id
+        }
+
+
+async def test_get_frigate_via_device_id_missing_parent(
+    hass: HomeAssistant,
+) -> None:
+    """Test no Frigate via_device_id link before the parent device exists."""
+    config_entry = create_mock_frigate_config_entry(hass)
+
+    with patch.dict(DeviceInfo.__annotations__, {"via_device_id": str}):
+        assert get_frigate_via_device(hass, config_entry) == {}
 
 
 async def test_entry_unload(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

Fixes #1115.

Home Assistant 2026.9 raises a runtime error when integrations call `device_registry.async_get_or_create` with the deprecated `via_device` device-info key. This prevents Frigate child entities, including camera entities, from being added.

This PR keeps compatibility with older Home Assistant releases by using `via_device` when `DeviceInfo` does not expose `via_device_id`, and uses the parent Frigate device registry id via `via_device_id` when the newer key is available. The Frigate update entity is left without `via_device_id` because it represents the parent device itself.

## Observed failure

On HA 2026.9.0b1, Frigate camera entities failed during setup with:

```text
RuntimeError: Detected code that calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead.
ERROR [homeassistant.components.camera] Error adding entity None for domain camera with platform frigate
```

## Verification

Validated in a Linux Python 3.13 container against this repository's pinned test dependencies:

- `pre-commit run --all-files`
- `pytest -p no:sugar` (`311 passed`, 100% coverage)
