### PR TITLE
Avoid deprecated Frigate parent device lookup

### DIFF
--- a/custom_components/frigate/__init__.py
+++ b/custom_components/frigate/__init__.py
@@ -111,7 +111,13 @@ def get_frigate_via_device(hass: HomeAssistant, entry: ConfigEntry) -> DeviceInf
     """Get the parent Frigate device link for this Home Assistant version."""
     identifier = get_frigate_device_identifier(entry)
     if "via_device_id" in DeviceInfo.__annotations__:
-        device = dr.async_get(hass).async_get_device({identifier})
+        device_registry = dr.async_get(hass)
+        if hasattr(device_registry, "async_get_device_by_identifier"):
+            device = device_registry.async_get_device_by_identifier(
+                identifier, entry.entry_id
+            )
+        else:
+            device = device_registry.async_get_device({identifier})
         if not device:
             return {}
         device_info: DeviceInfo = {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -52,15 +52,42 @@ async def test_get_frigate_via_device_id(hass: HomeAssistant) -> None:
     """Test getting the Frigate via_device_id link when Home Assistant supports it."""
     config_entry = create_mock_frigate_config_entry(hass)
     device_registry = dr.async_get(hass)
+    identifier = get_frigate_device_identifier(config_entry)
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers={get_frigate_device_identifier(config_entry)},
+        identifiers={identifier},
     )
 
     with patch.dict(DeviceInfo.__annotations__, {"via_device_id": str}):
         assert get_frigate_via_device(hass, config_entry) == {
             "via_device_id": device.id
         }
+
+
+async def test_get_frigate_via_device_id_uses_identifier_lookup(
+    hass: HomeAssistant,
+) -> None:
+    """Test getting the Frigate via_device_id link with the new registry lookup."""
+    config_entry = create_mock_frigate_config_entry(hass)
+    device_registry = dr.async_get(hass)
+    identifier = get_frigate_device_identifier(config_entry)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={identifier},
+    )
+
+    with patch.object(
+        device_registry,
+        "async_get_device_by_identifier",
+        return_value=device,
+        create=True,
+    ) as get_device:
+        with patch.dict(DeviceInfo.__annotations__, {"via_device_id": str}):
+            assert get_frigate_via_device(hass, config_entry) == {
+                "via_device_id": device.id
+            }
+
+    get_device.assert_called_once_with(identifier, config_entry.entry_id)
 
 
 async def test_get_frigate_via_device_id_missing_parent(


### PR DESCRIPTION
## Summary

Follow-up to #1116.

The previous fix avoids passing the deprecated `via_device` key on Home Assistant versions that expose `via_device_id`, but it still resolved the parent device with `device_registry.async_get_device`, which now emits a Home Assistant 2027.8 deprecation warning.

This keeps the older-HA fallback intact while using `async_get_device_by_identifier(identifier, entry.entry_id)` when Home Assistant provides it.

## Verification

- Installed on a live HA 2026.9.0b1 system running Frigate integration `5.15.5-wheemer.1`
- Restarted HA Core and confirmed Frigate entities loaded through HA MCP
- Checked post-restart HA Core logs; no Frigate `via_device` or `device_registry.async_get_device` deprecation warning was present
- `pre-commit run --all-files`
- `pytest -p no:sugar` (`312 passed`, 100% coverage)
