### PR TITLE
Bump integration version to 5.15.6

### DIFF
--- a/custom_components/frigate/manifest.json
+++ b/custom_components/frigate/manifest.json
@@ -16,5 +16,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/blakeblackshear/frigate-hass-integration/issues",
     "requirements": ["hass-web-proxy-lib==0.0.8","titlecase==2.4.1"],
-    "version": "5.15.4"
+    "version": "5.15.6"
 }


### PR DESCRIPTION
## Summary

- bump the integration manifest from 5.15.4 to 5.15.6
- provide a new installable version after the v5.15.5 tag was published with a stale manifest and incorrect release title

The existing v5.15.5 tag already points to the stale manifest, so a new version is required instead of reusing that tag.

## Validation

- `python -m json.tool custom_components/frigate/manifest.json`
- `git diff --check`

Closes #1118