### PR TITLE
Support base profile selection

### DIFF
--- a/custom_components/frigate/const.py
+++ b/custom_components/frigate/const.py
@@ -93,6 +93,9 @@ MIN_THRESHOLD = 5
 STATE_DETECTED = "active"
 STATE_IDLE = "idle"
 
+# Profiles
+PROFILE_NONE = "none"
+
 # Statuses
 STATUS_ERROR = "error"
 STATUS_RUNNING = "running"

--- a/custom_components/frigate/select.py
+++ b/custom_components/frigate/select.py
@@ -21,7 +21,7 @@ from . import (
     get_frigate_entity_unique_id,
     verify_frigate_version,
 )
-from .const import ATTR_CONFIG, DOMAIN, NAME
+from .const import ATTR_CONFIG, DOMAIN, NAME, PROFILE_NONE
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class FrigateProfileSelect(FrigateMQTTEntity, SelectEntity):
         """Construct a FrigateProfileSelect."""
         self._frigate_config = frigate_config
         self._profiles = profiles
-        self._attr_options = list(profiles.keys())
+        self._attr_options = [PROFILE_NONE] + list(profiles.keys())
         self._attr_current_option = None
         self._command_topic = f"{frigate_config['mqtt']['topic_prefix']}/profile/set"
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -61,6 +61,13 @@ async def test_profile_select_state(hass: HomeAssistant) -> None:
     assert entity_state
     assert entity_state.state == "away"
 
+    # Test setting profile back to base with "none"
+    async_fire_mqtt_message(hass, "frigate/profile/state", "none")
+    await hass.async_block_till_done()
+    entity_state = hass.states.get(TEST_SELECT_PROFILE_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "none"
+
     # Test bytes payload
     async_fire_mqtt_message(hass, "frigate/profile/state", b"home")
     await hass.async_block_till_done()
@@ -92,6 +99,19 @@ async def test_profile_select_option(hass: HomeAssistant, mqtt_mock: Any) -> Non
         "frigate/profile/set", "away", 0, False
     )
 
+    mqtt_mock.async_publish.reset_mock()
+
+    # Selecting "none" reverts Frigate to the base config.
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: TEST_SELECT_PROFILE_ENTITY_ID, "option": "none"},
+        blocking=True,
+    )
+    mqtt_mock.async_publish.assert_called_once_with(
+        "frigate/profile/set", "none", 0, False
+    )
+
 
 async def test_profile_select_options(hass: HomeAssistant) -> None:
     """Verify the select entity has correct options."""
@@ -99,7 +119,7 @@ async def test_profile_select_options(hass: HomeAssistant) -> None:
 
     entity_state = hass.states.get(TEST_SELECT_PROFILE_ENTITY_ID)
     assert entity_state
-    assert entity_state.attributes["options"] == ["away", "home"]
+    assert entity_state.attributes["options"] == ["none", "away", "home"]
 
 
 async def test_profile_select_device_info(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Along with the named profiles, allow a user to reset back to the base profile in Frigate