### PR TITLE
Add Enable switch to HA

### DIFF
--- a/custom_components/frigate/icons.py
+++ b/custom_components/frigate/icons.py
@@ -1,6 +1,6 @@
 """Handles icons for different entity types."""
 
-ICON_CAMERA_OFF = "mdi:video-off"
+ICON_CAMERA = "mdi:video"
 ICON_AUDIO = "mdi:ear-hearing"
 ICON_AUDIO_OFF = "mdi:ear-hearing-off"
 ICON_PTZ_AUTOTRACKER = "mdi:cctv"
@@ -31,6 +31,7 @@ ICON_DEFAULT_ON = "mdi:home"
 ICON_REVIEW_ALERTS = "mdi:bell-alert"
 ICON_REVIEW_DETECTIONS = "mdi:eye-check"
 
+ICON_CAMERA_OFF = "mdi:video-off"
 ICON_CAR_OFF = "mdi:car-off"
 ICON_DEFAULT_OFF = "mdi:home-outline"
 ICON_DOG_OFF = "mdi:dog-side-off"
@@ -49,10 +50,10 @@ def get_dynamic_icon_from_type(obj_type: str, is_on: bool) -> str:
     return ICON_DEFAULT_ON if is_on else ICON_DEFAULT_OFF
 
 
-def get_icon_from_switch(switch_type: str) -> str:
+def get_icon_from_switch(switch_type: str, is_on: bool = True) -> str:
     """Get icon for a specific switch type."""
     if switch_type == "enabled":
-        return ICON_CAMERA_OFF
+        return ICON_CAMERA if is_on else ICON_CAMERA_OFF
     if switch_type == "snapshots":
         return ICON_IMAGE_MULTIPLE
     if switch_type == "recordings":

--- a/custom_components/frigate/icons.py
+++ b/custom_components/frigate/icons.py
@@ -1,10 +1,12 @@
 """Handles icons for different entity types."""
 
+ICON_CAMERA_OFF = "mdi:camera-off"
 ICON_AUDIO = "mdi:ear-hearing"
 ICON_AUDIO_OFF = "mdi:ear-hearing-off"
 ICON_PTZ_AUTOTRACKER = "mdi:cctv"
 ICON_DESCRIPTIONS = "mdi:text-box-check"
 ICON_BICYCLE = "mdi:bicycle"
+ICON_BIRD = "mdi:bird"
 ICON_CAR = "mdi:car"
 ICON_CAT = "mdi:cat"
 ICON_CONTRAST = "mdi:contrast-circle"
@@ -49,6 +51,8 @@ def get_dynamic_icon_from_type(obj_type: str, is_on: bool) -> str:
 
 def get_icon_from_switch(switch_type: str) -> str:
     """Get icon for a specific switch type."""
+    if switch_type == "enabled":
+        return ICON_CAMERA_OFF
     if switch_type == "snapshots":
         return ICON_IMAGE_MULTIPLE
     if switch_type == "recordings":
@@ -88,5 +92,7 @@ def get_icon_from_type(obj_type: str) -> str:
         return ICON_COW
     if obj_type == "horse":
         return ICON_HORSE
+    if obj_type == "bird":
+        return ICON_BIRD
 
     return ICON_OTHER

--- a/custom_components/frigate/icons.py
+++ b/custom_components/frigate/icons.py
@@ -1,6 +1,6 @@
 """Handles icons for different entity types."""
 
-ICON_CAMERA_OFF = "mdi:camera-off"
+ICON_CAMERA_OFF = "mdi:video-off"
 ICON_AUDIO = "mdi:ear-hearing"
 ICON_AUDIO_OFF = "mdi:ear-hearing-off"
 ICON_PTZ_AUTOTRACKER = "mdi:cctv"

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -38,6 +38,7 @@ async def async_setup_entry(
     for camera in frigate_config["cameras"].keys():
         entities.extend(
             [
+                FrigateSwitch(entry, frigate_config, camera, "enabled", True),
                 FrigateSwitch(entry, frigate_config, camera, "detect", True),
                 FrigateSwitch(entry, frigate_config, camera, "motion", True),
                 FrigateSwitch(entry, frigate_config, camera, "recordings", True),

--- a/custom_components/frigate/switch.py
+++ b/custom_components/frigate/switch.py
@@ -161,6 +161,7 @@ class FrigateSwitch(FrigateMQTTEntity, SwitchEntity):
     def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Handle a new received MQTT state message."""
         self._is_on = decode_if_necessary(msg.payload) == "ON"
+        self._icon = get_icon_from_switch(self._switch_namem, self._is_on)
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
I like to disable some of my indoor cameras when there's somebody at home (no need to spy on each other and it's quite a reduction in storage) and while Frigate has a disable switch for cameras, it isn't exposed to HA. Made this a while ago but forgot to open a PR earlier.
I've added icons for on and off and while I was at it, added an icon for the bird detection sensor too because who doesn't like to have a little bird in their Home Assistant?